### PR TITLE
Using player.isAuthenticated to resolve success callback

### DIFF
--- a/ios/Classes/SwiftGamesServicesPlugin.swift
+++ b/ios/Classes/SwiftGamesServicesPlugin.swift
@@ -21,6 +21,8 @@ public class SwiftGamesServicesPlugin: NSObject, FlutterPlugin {
       }
       if let vc = vc {
         self.viewController.present(vc, animated: true, completion: nil)
+      }
+      if player.isAuthenticated {
         result("success")
       }
     }

--- a/ios/Classes/SwiftGamesServicesPlugin.swift
+++ b/ios/Classes/SwiftGamesServicesPlugin.swift
@@ -21,9 +21,10 @@ public class SwiftGamesServicesPlugin: NSObject, FlutterPlugin {
       }
       if let vc = vc {
         self.viewController.present(vc, animated: true, completion: nil)
-      }
-      if player.isAuthenticated {
+      } else if player.isAuthenticated {
         result("success")
+      } else {
+        result("error")
       }
     }
   }


### PR DESCRIPTION
it is now resolving looking at the `player.isAuthenticated` flag rather than just replying "success" when the modal was shown for users to log in. Users that were already logged in will never get the "success" call in that flow.