### PR TITLE
update gradle properties to fix appcenter build

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
This PR updates gradle wrapper properties to the minimum supported version. Trying to build a project with game_services package on AppCenter which fails with the following error:

` Minimum supported Gradle version is 5.6.4. Current version is 4.10.2. If using the gradle wrapper, try editing the distributionUrl in /Users/runner/.pub-cache/hosted/pub.dartlang.org/games_services-0.2.4/android/gradle/wrapper/gradle-wrapper.properties to gradle-5.6.4-all.zip`

Full stack is here:

```
BUILD FAILED in 1m 18s
Running Gradle task 'assembleRelease'...                           80.1s
The built failed likely due to AndroidX incompatibilities in a plugin. The tool is about to try using Jetfier to solve the incompatibility.
Building plugin audioplayers...
Running Gradle task 'assembleAarRelease'...                        29.5s
✓ Built build/app/outputs/repo.
Building plugin games_services...
Running Gradle task 'assembleAarRelease'...                        10.5s
Gradle 4.10.2

> Configure project :
Resolved com.android.tools.build:gradle:3.6.1 in :classpath 
Resolved org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61 in :classpath 
Resolved com.google.gms:google-services:4.3.3 in :classpath 
Project games_services at : is either no Android app project or build version has not been set to override. Skipping...


FAILURE: Build failed with an exception.

* Where:
Build file '/Users/runner/.pub-cache/hosted/pub.dartlang.org/games_services-0.2.4/android/build.gradle' line: 25

* What went wrong:
A problem occurred evaluating root project 'games_services'.
> Failed to apply plugin [id 'com.android.internal.version-check']
   > Minimum supported Gradle version is 5.6.4. Current version is 4.10.2. If using the gradle wrapper, try editing the distributionUrl in /Users/runner/.pub-cache/hosted/pub.dartlang.org/games_services-0.2.4/android/gradle/wrapper/gradle-wrapper.properties to gradle-5.6.4-all.zip

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 10s

The plugin games_services could not be built due to the issue above.
```