### PR TITLE
[Kotlin] Fix autogenerated class GeneratedPluginRegistrant usage and missing constructor parameter

### DIFF
--- a/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
+++ b/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
@@ -20,7 +20,7 @@ import io.flutter.plugin.common.PluginRegistry.Registrar
 
 private const val CHANNEL_NAME = "games_services"
 
-class GamesServicesPlugin(private var activity: Activity?) : FlutterPlugin, MethodCallHandler, ActivityAware {
+class GamesServicesPlugin(private var activity: Activity? = null) : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     //region Variables
     private var googleSignInClient: GoogleSignInClient? = null


### PR DESCRIPTION
Flutter engine generates a file to register all plugins `GeneratedPluginRegistrant` which doesn't use parameters to create instances of the plugin for Kotlin:

```
@Keep
public final class GeneratedPluginRegistrant {
  public static void registerWith(@NonNull FlutterEngine flutterEngine) {
    ShimPluginRegistry shimPluginRegistry = new ShimPluginRegistry(flutterEngine);
      xyz.luan.audioplayers.AudioplayersPlugin.registerWith(shimPluginRegistry.registrarFor("xyz.luan.audioplayers.AudioplayersPlugin"));
    flutterEngine.getPlugins().add(new com.abedalkareem.games_services.GamesServicesPlugin());
    flutterEngine.getPlugins().add(new io.flutter.plugins.pathprovider.PathProviderPlugin());
    flutterEngine.getPlugins().add(new io.flutter.plugins.sharedpreferences.SharedPreferencesPlugin());
  }
}
```

This gives an error during compillation:

```
android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java:18: error: constructor GamesServicesPlugin in class GamesServicesPlugin cannot be applied to given types;
    flutterEngine.getPlugins().add(new com.abedalkareem.games_services.GamesServicesPlugin());
                                   ^                                    
  required: Activity                                                    
  found: no arguments                                                   
  reason: actual and formal argument lists differ in length             
1 error     
```

Which has an easy fix to give the optional parameter the default value of null:

```
class GamesServicesPlugin(private var activity: Activity? **= null**)
```