### PR TITLE
removing unused code + fixing channel livecycle

### DIFF
--- a/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
+++ b/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
@@ -8,6 +8,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.games.AchievementsClient
 import com.google.android.gms.games.Games
 import com.google.android.gms.games.LeaderboardsClient
+import android.widget.Toast;
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -84,6 +85,9 @@ class GamesServicesPlugin(private var activity: Activity? = null) : FlutterPlugi
 
     //region Leaderboards
     private fun showLeaderboards(result: Result) {
+        if (leaderboardsClient?.allLeaderboardsIntent == null) {
+            Toast.makeText(activity, "Please log to Google Play Games", Toast.LENGTH_LONG).show();
+        }
         leaderboardsClient?.allLeaderboardsIntent?.addOnSuccessListener { intent ->
             activity?.startActivityForResult(intent, 0)
             result.success("success")

--- a/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
+++ b/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
@@ -113,6 +113,12 @@ class GamesServicesPlugin(private var activity: Activity? = null) : FlutterPlugi
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         activity = binding.activity
+
+        // if channel was already created update it
+        if (channel != null) {
+            val handler = GamesServicesPlugin(binding.activity)
+            channel?.setMethodCallHandler(handler)
+        }
     }
 
     override fun onDetachedFromActivityForConfigChanges() {
@@ -144,13 +150,6 @@ class GamesServicesPlugin(private var activity: Activity? = null) : FlutterPlugi
         }
     }
 
-    companion object {
-        @JvmStatic
-        fun registerWith(registrar: Registrar) {
-            val channel = MethodChannel(registrar.messenger(), CHANNEL_NAME)
-            channel.setMethodCallHandler(GamesServicesPlugin(registrar.activity()))
-        }
-    }
     //endregion
 
 }


### PR DESCRIPTION
I have a problem where the activity is null on after the `onMethodCall` fires as the channel was created before the activity was attached to the FlutterPlugin class.

I think it's probably better to do: `channel?.setMethodCallHandler(this)` instead of creating a new class but I kept on the safe side.

Could you have a look at it? I tried this on the latest android release.

thanks