### PR TITLE
Use IDs defined in app resources on Android.

### DIFF
--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
@@ -259,7 +259,7 @@ class GamesServicesPlugin(private var activity: Activity? = null) : FlutterPlugi
       }
       Methods.showLeaderboards -> {
         val leaderboardID = call.argument<String>("leaderboardID") ?: ""
-        if (leaderboardID != "") showLeaderboard(leaderboardID, result)
+        if (leaderboardID != "") showLeaderboard(getIdFromResources(leaderboardID), result)
         else showLeaderboards(result)
       }
       Methods.showAchievements -> {

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
@@ -131,6 +131,16 @@ class GamesServicesPlugin(private var activity: Activity? = null) : FlutterPlugi
     }
   }
 
+  private fun showLeaderboard(leaderboardID: String, result: Result) {
+    showLoginErrorIfNotLoggedIn(result)
+    leaderboardsClient!!.getLeaderboardIntent(leaderboardID).addOnSuccessListener { intent ->
+      activity?.startActivityForResult(intent, 0)
+      result.success("success")
+    }.addOnFailureListener {
+      result.error("error", "${it.message}", null)
+    }
+  }
+
   private fun submitScore(leaderboardID: String, score: Int, result: Result) {
     showLoginErrorIfNotLoggedIn(result)
     leaderboardsClient?.submitScoreImmediate(leaderboardID, score.toLong())?.addOnSuccessListener {
@@ -248,7 +258,9 @@ class GamesServicesPlugin(private var activity: Activity? = null) : FlutterPlugi
         submitScore(leaderboardID, score, result)
       }
       Methods.showLeaderboards -> {
-        showLeaderboards(result)
+        val leaderboardID = call.argument<String>("leaderboardID") ?: ""
+        if (leaderboardID != "") showLeaderboard(leaderboardID, result)
+        else showLeaderboards(result)
       }
       Methods.showAchievements -> {
         showAchievements(result)

--- a/games_services/ios/Classes/SwiftGamesServicesPlugin.swift
+++ b/games_services/ios/Classes/SwiftGamesServicesPlugin.swift
@@ -118,7 +118,7 @@ public class SwiftGamesServicesPlugin: NSObject, FlutterPlugin {
       showAchievements()
       result("success")
     case "showLeaderboards":
-      let leaderboardID = (arguments?["iOSLeaderboardID"] as? String) ?? ""
+      let leaderboardID = (arguments?["leaderboardID"] as? String) ?? ""
       showLeaderboardWith(identifier: leaderboardID)
       result("success")
     case "signIn":

--- a/games_services/lib/games_services.dart
+++ b/games_services/lib/games_services.dart
@@ -16,7 +16,8 @@ class GamesServices {
   /// [percentComplete] the completion percent of the achievement, this parameter is
   /// optional in case of iOS.
   static Future<String?> unlock({achievement: Achievement}) async {
-    return await GamesServicesPlatform.instance.unlock(achievement: achievement);
+    return await GamesServicesPlatform.instance
+        .unlock(achievement: achievement);
   }
 
   /// Increment an [achievement].
@@ -26,7 +27,8 @@ class GamesServices {
   /// you can use this method to increment the steps.
   /// * only for Android (see https://developers.google.com/games/services/android/achievements#unlocking_achievements).
   static Future<String?> increment({achievement: Achievement}) async {
-    return await GamesServicesPlatform.instance.increment(achievement: achievement);
+    return await GamesServicesPlatform.instance
+        .increment(achievement: achievement);
   }
 
   /// Submit a [score] to specific leader board.
@@ -44,8 +46,12 @@ class GamesServices {
   }
 
   /// It will open the leaderboards screen.
-  static Future<String?> showLeaderboards({iOSLeaderboardID = ""}) async {
-    return await GamesServicesPlatform.instance.showLeaderboards(iOSLeaderboardID: iOSLeaderboardID);
+  static Future<String?> showLeaderboards(
+      {iOSLeaderboardID = "", androidLeaderboardID = ""}) async {
+    return await GamesServicesPlatform.instance.showLeaderboards(
+      iOSLeaderboardID: iOSLeaderboardID,
+      androidLeaderboardID: androidLeaderboardID,
+    );
   }
 
   /// To sign in the user.

--- a/games_services/pubspec.yaml
+++ b/games_services/pubspec.yaml
@@ -13,7 +13,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  games_services_platform_interface: ^2.0.0-nullsafety.1
+  games_services_platform_interface:
+    path: ../games_services_platform_interface
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/games_services_platform_interface/lib/game_services_platform_interface.dart
+++ b/games_services_platform_interface/lib/game_services_platform_interface.dart
@@ -62,7 +62,8 @@ abstract class GamesServicesPlatform extends PlatformInterface {
   }
 
   /// It will open the leaderboards screen.
-  Future<String?> showLeaderboards({iOSLeaderboardID = ""}) async {
+  Future<String?> showLeaderboards(
+      {iOSLeaderboardID = "", androidLeaderboardID = ""}) async {
     throw UnimplementedError("not implemented.");
   }
 

--- a/games_services_platform_interface/lib/method_channel_games_services.dart
+++ b/games_services_platform_interface/lib/method_channel_games_services.dart
@@ -35,8 +35,12 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
     return await _channel.invokeMethod("showAchievements");
   }
 
-  Future<String?> showLeaderboards({iOSLeaderboardID = ""}) async {
-    return await _channel.invokeMethod("showLeaderboards", {"iOSLeaderboardID": iOSLeaderboardID});
+  Future<String?> showLeaderboards(
+      {iOSLeaderboardID = "", androidLeaderboardID = ""}) async {
+    return await _channel.invokeMethod("showLeaderboards", {
+      "leaderboardID":
+          Helpers.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID,
+    });
   }
 
   Future<String?> signIn() async {
@@ -48,7 +52,8 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
   }
 
   Future<String?> showAccessPoint(AccessPointLocation location) async {
-    return await _channel.invokeMethod("showAccessPoint", {"location": location.toString().split(".").last});
+    return await _channel.invokeMethod(
+        "showAccessPoint", {"location": location.toString().split(".").last});
   }
 
   Future<String?> hideAccessPoint() async {

--- a/games_services_platform_interface/pubspec.yaml
+++ b/games_services_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: games_services_platform_interface
 description: A common platform interface for the games_services plugin.
 homepage: https://github.com/Abedalkareem/games_services
-version: 2.0.0-nullsafety.1
+version: 2.0.0-nullsafety.2
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'


### PR DESCRIPTION
Updated GameServicesPlugin.kt to support using games-ids.xml resource file to define ids for leaderboards/achievements in Android, as per Google Play's instructions. This will allow the import of the resource definitions provided by Google Play and prevent the need for maintaining different IDs for iOS and Android.