### PR TITLE
issue #53: Fixing crash when unlocking achievement

### DIFF
--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
@@ -123,11 +123,8 @@ class GamesServicesPlugin(private var activity: Activity? = null) : FlutterPlugi
 
   private fun unlock(achievementID: String, result: Result) {
     showLoginErrorIfNotLoggedIn(result)
-    achievementClient?.unlockImmediate(achievementID)?.addOnSuccessListener {
-      result.success("success")
-    }?.addOnFailureListener {
-      result.error("error", it.localizedMessage, null)
-    }
+    achievementClient?.unlock(achievementID)
+    result.success("success")
   }
 
   private fun increment(achievementID: String, count: Int, result: Result) {


### PR DESCRIPTION
Instead of `unlockImmediate` I used `unlock` method. This does not crash.

I'm not a Kotlin expert so maybe there is a proper fix using `unlockImmediate` method call but since this is high priority I will just use this approach. 