### PR TITLE
Fix native crash caused by callback error in Android

### DIFF
--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/SaveGame.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/SaveGame.kt
@@ -23,16 +23,16 @@ class SaveGame(private var activityPluginBinding: ActivityPluginBinding) {
 
   fun getSavedGames(result: MethodChannel.Result) {
     snapshotsClient?.load(true)
-      ?.addOnCompleteListener { task ->
+      ?.addOnSuccessListener { snapshotResult ->
         val gson = Gson()
-        val data = task.result.get()
+        val data = snapshotResult.get()
         if (data == null) {
           result.error(
             PluginError.FailedToGetSavedGames.errorCode(),
             PluginError.FailedToGetSavedGames.errorMessage(),
             null
           )
-          return@addOnCompleteListener
+          return@addOnSuccessListener
         }
         val items = data
           .toList()


### PR DESCRIPTION
This pull request fixes a native crash that occurs in the Android part of the library when something goes wrong, causing any client that uses the library to crash.

The issue was caused by an attempt to read the result value inside the `addOnCompleteListener` callback, which is called even if there's an exception. As a result, [task.getResult()](https://developers.google.com/android/reference/com/google/android/gms/tasks/Task#public-abstract-tresult-getresult) throws a [RuntimeExecutionException](https://developers.google.com/android/reference/com/google/android/gms/tasks/RuntimeExecutionException).

This pull request replaces `addOnCompleteListener` with `addOnSuccessListener`, which resolves the issue by using the correct callback and ensures that the library can be used without any issues on Android devices.