### PR TITLE
Add support of namespace property to support Android Gradle Plugin (A…

### DIFF
--- a/games_services/android/build.gradle
+++ b/games_services/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:8.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.13'
     }
@@ -27,6 +27,8 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
+
+    namespace 'com.abedalkareem.games_services'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
# Description

This PR add support of namespace property to support Android Gradle Plugin (AGP) 8. Projects with AGP < 4.2 will not supported anymore. It fixes the following error :

![Namespace error](https://github.com/bluefireteam/audioplayers/assets/3882599/0a31e353-9c2f-4c4c-9cb4-a07bddfd82f9)

_This screenshot is the error occuring with `audioplayers`._

See https://github.com/flutter/flutter/issues/125181#issuecomment-1538519471.

# Upgrade instructions

All Flutter projects should upgrade their child Android project to use AGP 8. In the `android/build.gradle` :

```gradle
buildscript {
  // ...

  dependencies {
    classpath 'com.android.tools.build:gradle:8.0.1'
    // ...
  }
}
```

Also, a namespace is required in the `android` section of `android/app/build.gradle` :

```gradle
android {
  // ...
  namespace 'your.namespace'
}
```

# Note

There's a way to still support AGP 4.2. All we have to do is :

```gradle
if (project.android.hasProperty("namespace")) {
  namespace 'com.abedalkareem.games_services'
}
```

But I'm not sure that it's the _best_ idea as AGP 4.2 is old. As you want, I can adapt my PR if you ask to 🙂