### PR TITLE
Add support of namespace property to support Android Gradle Plugin 8

### DIFF
--- a/games_services/android/build.gradle
+++ b/games_services/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:8.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.13'
     }
@@ -27,6 +27,8 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
+
+    namespace 'com.abedalkareem.games_services'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/games_services/android/build.gradle
+++ b/games_services/android/build.gradle
@@ -28,7 +28,9 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 31
 
-    namespace 'com.abedalkareem.games_services'
+    if (project.android.hasProperty('namespace')) {
+        namespace 'com.abedalkareem.games_services'
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/games_services/android/gradle/wrapper/gradle-wrapper.properties
+++ b/games_services/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 04 15:33:58 CEST 2021
+#Sat May 13 15:10:21 CEST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/games_services/example/android/app/build.gradle
+++ b/games_services/example/android/app/build.gradle
@@ -28,10 +28,11 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     compileSdkVersion 32
 
+    namespace 'com.abedalkareem.game_services_example'
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
-
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).

--- a/games_services/example/android/build.gradle
+++ b/games_services/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:8.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/games_services/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/games_services/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 03 00:00:20 GST 2020
+#Sat May 13 15:11:27 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip


### PR DESCRIPTION
This PR adds support of namespace property to support Android Gradle Plugin (AGP) 8. It fixes the following error :

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':game_services'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Please specify a namespace in the module's build.gradle file like so:

     android {
         namespace 'com.example.namespace'
     }

     If the package attribute is specified in the source AndroidManifest.xml, it can be migrated automatically to the namespace value in the build.gradle file using the AGP Upgrade Assistant; please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
Running Gradle task 'bundleRelease'...                           2 150ms
Gradle task bundleRelease failed with exit code 1
```

See https://github.com/flutter/flutter/issues/125181#issuecomment-1538519471.