### PR TITLE
Ensure all task exceptions are handled, to prevent crashes.

### DIFF
--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Achievements.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Achievements.kt
@@ -66,15 +66,16 @@ class Achievements(private var activityPluginBinding: ActivityPluginBinding) {
     activity ?: return
     achievementClient
       .load(true)
-      .addOnCompleteListener { task ->
-        val data = task.result.get()
+      .addOnSuccessListener { annotatedData ->
+        val data = annotatedData.get()
+
         if (data == null) {
           result.error(
             PluginError.FailedToLoadAchievements.errorCode(),
             PluginError.FailedToLoadAchievements.errorMessage(),
             null
           )
-          return@addOnCompleteListener
+          return@addOnSuccessListener
         }
         val handler = CoroutineExceptionHandler { _, exception ->
           result.error(

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Leaderboards.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Leaderboards.kt
@@ -56,15 +56,16 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) {
   ) {
     activity ?: return
     leaderboardsClient.loadTopScores(leaderboardID, span, leaderboardCollection, maxResults)
-      .addOnCompleteListener { task ->
-        val data = task.result.get()
+      .addOnSuccessListener { annotatedData ->
+        val data = annotatedData.get()
+
         if (data == null) {
           result.error(
             PluginError.FailedToLoadLeaderboardScores.errorCode(),
             PluginError.FailedToLoadLeaderboardScores.errorMessage(),
             null
           )
-          return@addOnCompleteListener
+          return@addOnSuccessListener
         }
         val handler = CoroutineExceptionHandler { _, exception ->
           result.error(

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Leaderboards.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Leaderboards.kt
@@ -56,16 +56,15 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) {
   ) {
     activity ?: return
     leaderboardsClient.loadTopScores(leaderboardID, span, leaderboardCollection, maxResults)
-      .addOnSuccessListener { annotatedData ->
-        val data = annotatedData.get()
-
+      .addOnCompleteListener { task ->
+        val data = task.result.get()
         if (data == null) {
           result.error(
             PluginError.FailedToLoadLeaderboardScores.errorCode(),
             PluginError.FailedToLoadLeaderboardScores.errorMessage(),
             null
           )
-          return@addOnSuccessListener
+          return@addOnCompleteListener
         }
         val handler = CoroutineExceptionHandler { _, exception ->
           result.error(

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/SaveGame.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/SaveGame.kt
@@ -55,8 +55,9 @@ class SaveGame(private var activityPluginBinding: ActivityPluginBinding) {
       .setDescription(desc)
       .build()
     snapshotsClient.open(name, true, SnapshotsClient.RESOLUTION_POLICY_MOST_RECENTLY_MODIFIED)
-      .addOnCompleteListener { task ->
-        val snapshot = task.result.data
+      .addOnSuccessListener { annotatedData ->
+        val snapshot = annotatedData.data
+
         if (snapshot != null) {
           // Set the data payload for the snapshot
           snapshot.snapshotContents.writeBytes(data.toByteArray())
@@ -76,6 +77,13 @@ class SaveGame(private var activityPluginBinding: ActivityPluginBinding) {
             null
           )
         }
+      }
+      .addOnFailureListener {
+        result.error(
+          PluginError.FailedToSaveGame.errorCode(),
+          it.localizedMessage,
+          null
+        )
       }
   }
 


### PR DESCRIPTION
`task.result.get()` crashes for me when calling `loadAchievement` in one scenario. I don't think this is intentional? Seems like this should be handled by the failure listener which was already present. After this change it is.

I also changed a similar case with leaderboards and saves. After this no completeListeners should assume that data exists.

Disclaimer: I don't really know Kotlin and haven't worked with native Android in years, but it seems pretty straightforward.