### PR TITLE
Handle consent exception when calling `loadLeaderboardScores` with `Scope.friendsOnly`

### DIFF
--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Leaderboards.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Leaderboards.kt
@@ -17,14 +17,59 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import android.util.Log
+import com.google.android.gms.games.FriendsResolutionRequiredException
+import io.flutter.plugin.common.PluginRegistry
 
-class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) {
+class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) :
+  PluginRegistry.ActivityResultListener {
 
   private val imageLoader = AppImageLoader()
   private val leaderboardsClient: LeaderboardsClient
     get() {
       return PlayGames.getLeaderboardsClient(activityPluginBinding.activity)
     }
+
+  // used to retry [loadLeaderboardScore] after being granted friends list access
+  private var leaderboardID: String? = null;
+  private var span: Int? = null;
+  private var leaderboardCollection: Int? = null;
+  private var maxResults: Int? = null;
+  private var result: MethodChannel.Result? = null;
+  private var errorMessage: String? = null;
+
+  // handle result from firends list permission request
+  override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?): Boolean {
+    activityPluginBinding.removeActivityResultListener(this)
+    return if (requestCode == 26703) {
+      // retry loadLeaderboard if permission granted, otherwise throw the original error
+      if (resultCode == -1 && leaderboardID != null) {
+        loadLeaderboardScores(
+          activityPluginBinding.activity,
+          leaderboardID!!,
+          span!!,
+          leaderboardCollection!!,
+          maxResults!!,
+          result!!
+        )
+      } else {
+        result?.error(
+          PluginError.FailedToLoadLeaderboardScores.errorCode(),
+          errorMessage,
+          null,
+        )
+      }
+      leaderboardID = null
+      span = null
+      leaderboardCollection = null
+      maxResults = null
+      result = null
+      errorMessage = null;
+      true
+    } else {
+      false
+    }
+  }
 
   fun showLeaderboards(activity: Activity?, leaderboardID: String, result: MethodChannel.Result) {
     val onSuccessListener: ((Intent) -> Unit) = { intent ->
@@ -46,6 +91,8 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) {
     }
   }
 
+//  private
+
   fun loadLeaderboardScores(
     activity: Activity?,
     leaderboardID: String,
@@ -56,15 +103,16 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) {
   ) {
     activity ?: return
     leaderboardsClient.loadTopScores(leaderboardID, span, leaderboardCollection, maxResults)
-      .addOnCompleteListener { task ->
-        val data = task.result.get()
+      .addOnSuccessListener { annotatedData ->
+        val data = annotatedData.get()
+
         if (data == null) {
           result.error(
             PluginError.FailedToLoadLeaderboardScores.errorCode(),
             PluginError.FailedToLoadLeaderboardScores.errorMessage(),
             null
           )
-          return@addOnCompleteListener
+          return@addOnSuccessListener
         }
         val handler = CoroutineExceptionHandler { _, exception ->
           result.error(
@@ -75,33 +123,54 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) {
         }
 
         CoroutineScope(Dispatchers.Main + handler).launch {
-          val achievements = mutableListOf<LeaderboardScoreData>()
+          val scores = mutableListOf<LeaderboardScoreData>()
           for (item in data.scores) {
-            val lockedImage =
+            val image =
               item.scoreHolderIconImageUri.let { imageLoader.loadImageFromUri(activity, it) }
-            achievements.add(
+            scores.add(
               LeaderboardScoreData(
                 item.rank,
                 item.displayScore,
                 item.rawScore,
                 item.timestampMillis,
                 item.scoreHolderDisplayName,
-                lockedImage,
+                image,
               )
             )
           }
           val gson = Gson()
-          val string = gson.toJson(achievements) ?: ""
+          val string = gson.toJson(scores) ?: ""
           data.release()
           result.success(string)
         }
       }
       .addOnFailureListener {
-        result.error(
-          PluginError.FailedToLoadLeaderboardScores.errorCode(),
-          it.localizedMessage,
-          null
-        )
+        // handle friends list CONSENT_REQUIRED error to trigger permission request dialog
+        if (it is FriendsResolutionRequiredException) {
+          this.leaderboardID = leaderboardID
+          this.span = span
+          this.leaderboardCollection = leaderboardCollection
+          this.maxResults = maxResults
+          this.result = result
+          this.errorMessage = it.localizedMessage
+          val pendingIntent = it.resolution
+          activityPluginBinding.addActivityResultListener(this)
+          activity.startIntentSenderForResult(
+            pendingIntent.intentSender,
+            26703,
+            null,
+            0,
+            0,
+            0
+          )
+          Log.i("GamesServices", "Friends list access requested")
+        } else {
+          result.error(
+            PluginError.FailedToLoadLeaderboardScores.errorCode(),
+            it.localizedMessage,
+            null
+          )
+        }
       }
   }
 

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Leaderboards.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Leaderboards.kt
@@ -38,7 +38,7 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) :
   private var result: MethodChannel.Result? = null;
   private var errorMessage: String? = null;
 
-  // handle result from firends list permission request
+  // handle result from friends list permission request
   override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?): Boolean {
     activityPluginBinding.removeActivityResultListener(this)
     return if (requestCode == 26703) {

--- a/games_services/pubspec.lock
+++ b/games_services/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -58,10 +58,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -87,10 +87,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.3.0"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=1.22.0"


### PR DESCRIPTION
The exception is caught and triggers the built-in permission resolution dialog. If permission is granted, the method is called again. Otherwise, the original error is thrown, allowing the developer to handle as seen fit.

Also renames the `achievements` variable to `scores` in `Leaderboards.loadLeaderboardScores`.

Closes #133.