### PR TITLE
Add signInFailed check to prevent hanging on hot reload.

### DIFF
--- a/games_services/darwin/Classes/Auth.swift
+++ b/games_services/darwin/Classes/Auth.swift
@@ -5,11 +5,26 @@ import FlutterMacOS
 #endif
 
 class Auth: BaseGamesServices {
+    
+  // track if previous sign in was cancelled (failed) for debugging
+  // this prevents hanging on `signIn` when hot reloading
+  #if DEBUG
+    var debugSignInFailed = false
+  #endif
 
   func authenticateUser(result: @escaping FlutterResult) {
+    #if DEBUG
+      if (self.debugSignInFailed) {
+        result(PluginError.failedToAuthenticate.flutterError())
+        return
+      }
+    #endif
     currentPlayer.authenticateHandler = { vc, error in
       guard error == nil else {
-        result(error?.flutterError(code: .failedToAuthenticate))
+        #if DEBUG
+          self.debugSignInFailed = true
+        #endif
+        result(error!.flutterError(code: .failedToAuthenticate))
         return
       }
       if let vc = vc {

--- a/games_services/pubspec.yaml
+++ b/games_services/pubspec.yaml
@@ -1,6 +1,6 @@
 name: games_services
 description: A new Flutter plugin to support game center and google play games services.
-version: 4.0.0
+version: 4.0.1
 homepage: https://github.com/Abedalkareem/games_services
 repository: https://github.com/Abedalkareem/games_services
 issue_tracker: https://github.com/Abedalkareem/games_services/issues


### PR DESCRIPTION
Due to Game Center's authentication implementation, the `authenticateHandler` does nothing if called again after a user cancels sign in if the app never left the foreground. This can lead to hanging of the app if the `signIn` call is awaited.

While it can generally fall upon the developer to account for this case in Flutter, a situation occurs when dealing with hot reloads that the developer cannot account for.

This PR adds a check for a previous failed sign in attempt to the `Auth` class via Swift's conditional debug compilation to resolve this issue. Release builds are unaffected.