### PR TITLE
Add isAuthenticated check alongside DEBUG signInFailed.

### DIFF
--- a/games_services/darwin/Classes/Auth.swift
+++ b/games_services/darwin/Classes/Auth.swift
@@ -14,7 +14,7 @@ class Auth: BaseGamesServices {
 
   func authenticateUser(result: @escaping FlutterResult) {
     #if DEBUG
-      if (self.debugSignInFailed) {
+      if (self.debugSignInFailed && !isAuthenticated) {
         result(PluginError.failedToAuthenticate.flutterError())
         return
       }


### PR DESCRIPTION
There is a scenario where upon cancelling sign-in on first launch, then selecting sign-in via the notification popup that occurs in subsequent launches, sign-in will fail then succeed. A check for `!isAuthenticated` ensures that the player banner pops up on successful sign in in this scenario to keep the debug and release experience in line.