### PR TITLE
Add PlayerData class to return more score holder details.

### DIFF
--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Leaderboards.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Leaderboards.kt
@@ -3,6 +3,7 @@ package com.abedalkareem.games_services
 import android.app.Activity
 import android.content.Intent
 import com.abedalkareem.games_services.models.LeaderboardScoreData
+import com.abedalkareem.games_services.models.PlayerData
 import com.abedalkareem.games_services.util.AppImageLoader
 import com.abedalkareem.games_services.util.PluginError
 import com.abedalkareem.games_services.util.errorCode
@@ -125,7 +126,7 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) :
         CoroutineScope(Dispatchers.Main + handler).launch {
           val scores = mutableListOf<LeaderboardScoreData>()
           for (item in data.scores) {
-            val image =
+            val scoreHolderIconImage =
               item.scoreHolderIconImageUri.let { imageLoader.loadImageFromUri(activity, it) }
             scores.add(
               LeaderboardScoreData(
@@ -133,8 +134,11 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) :
                 item.displayScore,
                 item.rawScore,
                 item.timestampMillis,
-                item.scoreHolderDisplayName,
-                image,
+                PlayerData(
+                  item.scoreHolderDisplayName,
+                  item.scoreHolder?.playerId,
+                  scoreHolderIconImage
+                )
               )
             )
           }

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/models/LeaderboardScoreData.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/models/LeaderboardScoreData.kt
@@ -5,6 +5,5 @@ data class LeaderboardScoreData(
   val displayScore: String,
   val rawScore: Long,
   val timestampMillis: Long,
-  val scoreHolderDisplayName: String,
-  val scoreHolderIconImage: String?
+  val scoreHolder: PlayerData
 )

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/models/PlayerData.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/models/PlayerData.kt
@@ -1,0 +1,9 @@
+package com.abedalkareem.games_services.models
+
+data class PlayerData (
+    val displayName: String,
+    // playerID may be null if privacy settings do not allow current player
+    // to see info about the this player
+    val playerID: String?,
+    val iconImage: String?
+)

--- a/games_services/darwin/Classes/Leaderboards.swift
+++ b/games_services/darwin/Classes/Leaderboards.swift
@@ -64,13 +64,15 @@ class Leaderboards: BaseGamesServices {
             #else
             let imageData = try? await item.player.loadPhoto(for: .normal).pngData()
             #endif
-            let image = imageData?.base64EncodedString()
+            let scoreHolderIconImage = imageData?.base64EncodedString()
             items.append(LeaderboardScoreData(rank: item.rank,
                                               displayScore: item.formattedScore,
                                               rawScore: item.score,
                                               timestampMillis: Int(item.date.timeIntervalSince1970),
-                                              scoreHolderDisplayName: item.player.displayName,
-                                             scoreHolderIconImage: image))
+                                              scoreHolder: PlayerData(
+                                                displayName: item.player.displayName, playerID: item.player.gamePlayerID, teamPlayerID: item.player.teamPlayerID,
+                                                iconImage: scoreHolderIconImage
+                                              )))
           }
           if let data = try? JSONEncoder().encode(items) {
             let string = String(data: data, encoding: String.Encoding.utf8)

--- a/games_services/darwin/Classes/Models/LeaderboardScoreData.swift
+++ b/games_services/darwin/Classes/Models/LeaderboardScoreData.swift
@@ -4,6 +4,5 @@ struct LeaderboardScoreData: Codable {
   var displayScore: String
   var rawScore: Int
   var timestampMillis: Int
-  var scoreHolderDisplayName: String
-  var scoreHolderIconImage: String?
+  var scoreHolder: PlayerData
 }

--- a/games_services/darwin/Classes/Models/PlayerData.swift
+++ b/games_services/darwin/Classes/Models/PlayerData.swift
@@ -1,0 +1,7 @@
+
+struct PlayerData: Codable {
+  var displayName: String
+  var playerID: String
+  var teamPlayerID: String
+  var iconImage: String?
+}

--- a/games_services/lib/src/models/leaderboard_score_data.dart
+++ b/games_services/lib/src/models/leaderboard_score_data.dart
@@ -7,9 +7,10 @@ class LeaderboardScoreData {
   final int timestampMillis;
   final PlayerData scoreHolder;
 
-  // TODO: deprecate in favor of accessing PlayerData properties directly
   // provided to maintain backwards compatibility
+  @Deprecated('Use scoreHolder.displayName instead.')
   String get scoreHolderDisplayName => scoreHolder.displayName;
+  @Deprecated('Use scoreHolder.iconImage instead.')
   String? get scoreHolderIconImage => scoreHolder.iconImage;
 
   const LeaderboardScoreData({

--- a/games_services/lib/src/models/leaderboard_score_data.dart
+++ b/games_services/lib/src/models/leaderboard_score_data.dart
@@ -1,18 +1,23 @@
+import 'package:games_services/src/models/player_data.dart';
+
 class LeaderboardScoreData {
   final int rank;
   final String displayScore;
   final int rawScore;
   final int timestampMillis;
-  final String scoreHolderDisplayName;
-  final String? scoreHolderIconImage;
+  final PlayerData scoreHolder;
+
+  // TODO: deprecate in favor of accessing PlayerData properties directly
+  // provided to maintain backwards compatibility
+  String get scoreHolderDisplayName => scoreHolder.displayName;
+  String? get scoreHolderIconImage => scoreHolder.iconImage;
 
   const LeaderboardScoreData({
     required this.rank,
     required this.displayScore,
     required this.rawScore,
     required this.timestampMillis,
-    required this.scoreHolderDisplayName,
-    this.scoreHolderIconImage,
+    required this.scoreHolder,
   });
 
   factory LeaderboardScoreData.fromJson(Map<String, dynamic> json) {
@@ -21,9 +26,7 @@ class LeaderboardScoreData {
       displayScore: json["displayScore"],
       rawScore: json["rawScore"],
       timestampMillis: json["timestampMillis"],
-      scoreHolderDisplayName: json["scoreHolderDisplayName"],
-      scoreHolderIconImage:
-          (json["scoreHolderIconImage"] as String?)?.replaceAll("\n", ""),
+      scoreHolder: PlayerData.fromJson(json["scoreHolder"]),
     );
   }
 }

--- a/games_services/lib/src/models/player_data.dart
+++ b/games_services/lib/src/models/player_data.dart
@@ -1,0 +1,24 @@
+class PlayerData {
+  // can be null on Android due to privacy settings
+  final String? playerID;
+  final String displayName;
+  // only available from GameCenter
+  final String? teamPlayerID;
+  final String? iconImage;
+
+  const PlayerData({
+    required this.playerID,
+    required this.displayName,
+    this.teamPlayerID,
+    this.iconImage,
+  });
+
+  factory PlayerData.fromJson(Map<String, dynamic> json) {
+    return PlayerData(
+      playerID: json["playerID"],
+      displayName: json["displayName"],
+      teamPlayerID: json["teamPlayerID"],
+      iconImage: (json["iconImage"] as String?)?.replaceAll("\n", ""),
+    );
+  }
+}

--- a/games_services/lib/src/models/player_data.dart
+++ b/games_services/lib/src/models/player_data.dart
@@ -1,10 +1,11 @@
 class PlayerData {
-  // can be null on Android due to privacy settings
+  /// Value can be `null` on Android due to privacy settings
   final String? playerID;
   final String displayName;
-  // only available from GameCenter
-  final String? teamPlayerID;
   final String? iconImage;
+
+  /// only available from GameCenter
+  final String? teamPlayerID;
 
   const PlayerData({
     required this.playerID,


### PR DESCRIPTION
Adds a `PlayerData` class to return inside a `LeaderboardScoreData` object. The `PlayerData` object includes the previously available `displayName` & `iconImage` and adds `playerID` & `teamPlayerID`.

`teamPlayerID` is only available on iOS/macOS and `playerID` can be null on Android due to privacy settings.

`scoreHolderDisplayName` & `scoreHolderIconImage` getters are added to `LeaderboardScoreData` to maintain backwards compatibility.

Closes #146.