### PR TITLE
Add ability to get Play Games auth code for use with backends.

### DIFF
--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Auth.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Auth.kt
@@ -9,7 +9,6 @@ import com.abedalkareem.games_services.models.value
 import com.abedalkareem.games_services.util.PluginError
 import com.abedalkareem.games_services.util.errorCode
 import com.google.android.gms.auth.api.Auth
-import com.google.android.gms.drive.Drive
 import com.google.android.gms.games.AuthenticationResult
 import com.google.android.gms.games.PlayGames
 import com.google.android.gms.tasks.Task
@@ -42,6 +41,16 @@ class Auth : PluginRegistry.ActivityResultListener {
     }.addOnFailureListener {
       it.let { result -> Log.i("PlayService", "isAuthenticated: ${result.localizedMessage} toString: $result") }
       finishPendingOperationWithError(PluginError.FailedToAuthenticate.errorCode(), it.message ?: "")
+    }
+  }
+
+  fun getAuthCode(clientID: String, activity: Activity?, result: MethodChannel.Result) {
+    activity ?: return
+    val gamesSignInClient = PlayGames.getGamesSignInClient(activity)
+    gamesSignInClient.requestServerSideAccess(clientID, false).addOnSuccessListener {
+      result.success(it)
+    }.addOnFailureListener {
+      result.error(PluginError.FailedToGetAuthCode.errorCode(), it.message ?: "", null)
     }
   }
 

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
@@ -101,6 +101,10 @@ class GamesServicesPlugin : FlutterPlugin,
       Method.IsSignedIn -> {
         auth.isSignedIn(activity, result)
       }
+      Method.GetAuthCode -> {
+        val clientID = call.argument<String>("clientID") ?: ""
+        auth.getAuthCode(clientID, activity, result)
+      }
       Method.ShowAchievements -> {
         achievements?.showAchievements(activity, result)
       }

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/models/Method.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/models/Method.kt
@@ -4,7 +4,7 @@ enum class Method {
   Unlock, Increment, SubmitScore, ShowLeaderboards, ShowAchievements,
   LoadAchievements, SignIn, IsSignedIn, GetPlayerID, GetPlayerName,
   GetPlayerHiResImage, GetPlayerIconImage, GetPlayerScore, SaveGame,
-  LoadGame, GetSavedGames, DeleteGame, LoadLeaderboardScores
+  LoadGame, GetSavedGames, DeleteGame, LoadLeaderboardScores, GetAuthCode
 }
 
 fun Method.value(): String {

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/util/PluginError.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/util/PluginError.kt
@@ -4,7 +4,7 @@ enum class PluginError {
   FailedToSendScore, FailedToGetScore, FailedToGetPlayerId, FailedToGetPlayerName,
   FailedToGetPlayerProfileImage, FailedToSendAchievement, FailedToShowAchievements,
   FailedToIncrementAchievements, FailedToLoadAchievements, FailedToAuthenticate,
-  FailedToSignOut, NotAuthenticated, NotSupportedForThisOSVersion, FailedToSaveGame,
+  FailedToGetAuthCode, NotAuthenticated, NotSupportedForThisOSVersion, FailedToSaveGame,
   FailedToLoadGame, FailedToGetSavedGames, LeaderboardNotFound, FailedToDeleteSavedGame,
   FailedToLoadLeaderboardScores
 }
@@ -32,6 +32,9 @@ fun PluginError.errorCode(): String {
     PluginError.FailedToAuthenticate -> {
       return "failed_to_authenticate"
     }
+    PluginError.FailedToGetAuthCode -> {
+      return "failed_to_get_auth_code"
+    }
     PluginError.NotSupportedForThisOSVersion -> {
       return "not_supported_for_this_os_version"
     }
@@ -47,8 +50,8 @@ fun PluginError.errorCode(): String {
     PluginError.FailedToGetPlayerProfileImage -> {
       return "failed_to_get_player_profile_image"
     }
-    PluginError.FailedToSignOut -> {
-      return "failed_to_sign_out"
+    PluginError.FailedToGetAuthCode -> {
+      return "failed_to_get_auth_code"
     }
     PluginError.NotAuthenticated -> {
       return "not_authenticated"
@@ -94,6 +97,9 @@ fun PluginError.errorMessage(): String {
     PluginError.FailedToAuthenticate -> {
       return "Failed to authenticate"
     }
+    PluginError.FailedToGetAuthCode -> {
+      return "Failed to get authCode"
+    }
     PluginError.NotSupportedForThisOSVersion -> {
       return "Not supported for this OS version"
     }
@@ -109,8 +115,8 @@ fun PluginError.errorMessage(): String {
     PluginError.FailedToGetPlayerProfileImage -> {
       return "Failed to get player profile image"
     }
-    PluginError.FailedToSignOut -> {
-      return "Failed to sign out"
+    PluginError.FailedToGetAuthCode -> {
+      return "Failed to get server auth code"
     }
     PluginError.NotAuthenticated -> {
       return "Player not authenticated, Please make sure to call signIn() first"

--- a/games_services/lib/src/game_auth.dart
+++ b/games_services/lib/src/game_auth.dart
@@ -10,4 +10,9 @@ abstract class GameAuth {
   /// Check to see if the user is currently signed into Game Center or Google Play Games.
   static Future<bool> get isSignedIn async =>
       await GamesServicesPlatform.instance.isSignedIn ?? false;
+
+  /// Retrieve a Google Play Games `server_auth_code` to be used by a backend,
+  /// such as Firebase, to authenticate the user. `null` on other platforms.
+  static Future<String?> getAuthCode(String clientID) async =>
+      await GamesServicesPlatform.instance.getAuthCode(clientID);
 }

--- a/games_services/lib/src/games_services.dart
+++ b/games_services/lib/src/games_services.dart
@@ -19,6 +19,11 @@ class GamesServices {
   /// Check to see if the user is currently signed into Game Center or Google Play Games.
   static Future<bool> get isSignedIn => GameAuth.isSignedIn;
 
+  /// Retrieve a Google Play Games `server_auth_code` to be used by a backend,
+  /// such as Firebase, to authenticate the user. `null` on other platforms.
+  static Future<String?> getAuthCode(String clientID) async =>
+      await GameAuth.getAuthCode(clientID);
+
   /// Open the device's default achievements screen.
   static Future<String?> showAchievements() async {
     return await Achievements.showAchievements();

--- a/games_services/pubspec.yaml
+++ b/games_services/pubspec.yaml
@@ -1,6 +1,6 @@
 name: games_services
 description: A new Flutter plugin to support game center and google play games services.
-version: 4.0.0
+version: 4.0.1
 homepage: https://github.com/Abedalkareem/games_services
 repository: https://github.com/Abedalkareem/games_services
 issue_tracker: https://github.com/Abedalkareem/games_services/issues
@@ -13,8 +13,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  games_services_platform_interface: ^4.0.0
-    # path: ../games_services_platform_interface/
+  games_services_platform_interface: # ^4.0.0
+    path: ../games_services_platform_interface/
     # uncomment in time of development.
     # git:
     #   url: https://github.com/Abedalkareem/games_services

--- a/games_services_platform_interface/lib/game_services_platform_interface.dart
+++ b/games_services_platform_interface/lib/game_services_platform_interface.dart
@@ -111,6 +111,11 @@ abstract class GamesServicesPlatform extends PlatformInterface {
   /// Check to see if the user is currently signed into Game Center or Google Play Games.
   Future<bool?> get isSignedIn => throw UnimplementedError("not implemented.");
 
+  /// Retrieve Google Play Games [server_auth_code] to be used by an auth provider,
+  /// such as Firebase, to authenticate the user. [null] on other platforms.
+  Future<String?> getAuthCode(String clientID) =>
+      throw UnimplementedError("not implemented.");
+
   /// Show the Game Center Access Point for the current player.
   Future<String?> showAccessPoint(AccessPointLocation location) async {
     throw UnimplementedError("not implemented.");

--- a/games_services_platform_interface/lib/src/game_services_platform_impl.dart
+++ b/games_services_platform_interface/lib/src/game_services_platform_impl.dart
@@ -90,6 +90,11 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
   Future<bool?> get isSignedIn => _channel.invokeMethod("isSignedIn");
 
   @override
+  Future<String?> getAuthCode(String clientID) => Device.isPlatformAndroid
+      ? _channel.invokeMethod("getAuthCode", {"clientID": clientID})
+      : Future.value(null);
+
+  @override
   Future<bool?> get playerIsUnderage async {
     if (Device.isPlatformAndroid) {
       return Future.value(false);

--- a/games_services_platform_interface/pubspec.yaml
+++ b/games_services_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: games_services_platform_interface
 description: A common platform interface for the games_services plugin.
 homepage: https://github.com/Abedalkareem/games_services
-version: 4.0.0
+version: 4.0.1
 
 environment:
   sdk: '>=2.12.0 <4.0.0'


### PR DESCRIPTION
This can be used with `firebase_auth` ^4.17.0 to sign into Firebase automatically when logged into Play Games, as well as with any backend service that needs to access Play Games via credentials.

Closes #145