### PR TITLE
loadPlayerScoreObject for rank retrieval, and other enhancements

### DIFF
--- a/games_services/android/build.gradle
+++ b/games_services/android/build.gradle
@@ -48,6 +48,6 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'com.google.code.gson:gson:2.10.1'
-    api "com.google.android.gms:play-services-games-v2:17.0.0"
-    api 'com.google.android.gms:play-services-auth:20.6.0'
+    api "com.google.android.gms:play-services-games-v2:19.0.0"
+    api 'com.google.android.gms:play-services-auth:20.7.0'
 }

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
@@ -134,11 +134,18 @@ class GamesServicesPlugin : FlutterPlugin,
       Method.SubmitScore -> {
         val leaderboardID = call.argument<String>("leaderboardID") ?: ""
         val score = call.argument<Int>("value") ?: 0
-        leaderboards?.submitScore(leaderboardID, score, result)
+        val token = call.argument<String>("token") ?: ""
+        leaderboards?.submitScore(leaderboardID, score, token, result)
       }
       Method.GetPlayerScore -> {
         val leaderboardID = call.argument<String>("leaderboardID") ?: ""
         leaderboards?.getPlayerScore(leaderboardID, result)
+      }
+      Method.GetPlayerScoreObject -> {
+        val leaderboardID = call.argument<String>("leaderboardID") ?: ""
+        val span = call.argument<Int>("span") ?: 0
+        val leaderboardCollection = call.argument<Int>("leaderboardCollection") ?: 0
+        leaderboards?.getPlayerScoreObject(activity, leaderboardID, span, leaderboardCollection, result)
       }
       Method.GetPlayerID -> {
         player?.getPlayerID(activity, result)

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/models/LeaderboardScoreData.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/models/LeaderboardScoreData.kt
@@ -5,5 +5,6 @@ data class LeaderboardScoreData(
   val displayScore: String,
   val rawScore: Long,
   val timestampMillis: Long,
-  val scoreHolder: PlayerData
+  val scoreHolder: PlayerData,
+  val token: String?
 )

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/models/Method.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/models/Method.kt
@@ -3,7 +3,7 @@ package com.abedalkareem.games_services.models
 enum class Method {
   Unlock, Increment, SubmitScore, ShowLeaderboards, ShowAchievements,
   LoadAchievements, SignIn, IsSignedIn, GetPlayerID, GetPlayerName,
-  GetPlayerHiResImage, GetPlayerIconImage, GetPlayerScore, SaveGame,
+  GetPlayerHiResImage, GetPlayerIconImage, GetPlayerScore, GetPlayerScoreObject, SaveGame,
   LoadGame, GetSavedGames, DeleteGame, LoadLeaderboardScores, GetAuthCode
 }
 

--- a/games_services/darwin/Classes/Achievements.swift
+++ b/games_services/darwin/Classes/Achievements.swift
@@ -15,10 +15,10 @@ class Achievements: BaseGamesServices {
     result(nil)
   }
   
-  func report(achievementID: String, percentComplete: Double, result: @escaping FlutterResult) {
+  func report(achievementID: String, percentComplete: Double, showsCompletionBanner: Bool, result: @escaping FlutterResult) {
     let achievement = GKAchievement(identifier: achievementID)
     achievement.percentComplete = percentComplete
-    achievement.showsCompletionBanner = true
+    achievement.showsCompletionBanner = showsCompletionBanner
     GKAchievement.report([achievement]) { (error) in
       guard error == nil else {
         result(error?.flutterError(code: .failedToSendAchievement))
@@ -80,6 +80,18 @@ class Achievements: BaseGamesServices {
       result(PluginError.notSupportedForThisOSVersion.flutterError())
     }
   }
-  
+
+  func resetAchievements(result: @escaping FlutterResult) {
+    if #available(iOS 13.0, *) {
+      Task {
+        do {
+          try await GKAchievement.resetAchievements()
+          result(nil)
+          } catch {
+          result(error.flutterError(code: .failedToResetAchievements))
+        }
+      }
+    }
+  }
 }
 

--- a/games_services/darwin/Classes/Leaderboards.swift
+++ b/games_services/darwin/Classes/Leaderboards.swift
@@ -16,9 +16,10 @@ class Leaderboards: BaseGamesServices {
     result(nil)
   }
   
-  func report(score: Int, leaderboardID: String, result: @escaping FlutterResult) {
+  func report(score: Int, leaderboardID: String, token: String, result: @escaping FlutterResult) {
     let reportedScore = GKScore(leaderboardIdentifier: leaderboardID)
     reportedScore.value = Int64(score)
+    reportedScore.context = UInt64(token) ?? 0
     GKScore.report([reportedScore]) { (error) in
       guard error == nil else {
         result(error?.flutterError(code: .failedToSendScore))
@@ -36,6 +37,57 @@ class Leaderboards: BaseGamesServices {
           let response = try await leaderboard.first?.loadEntries(for: [currentPlayer], timeScope: .allTime)
           let (localPlayerEntry, _) = response ?? (nil, nil)
           result(localPlayerEntry?.score ?? 0)
+        } catch {
+          result(error.flutterError(code: .failedToGetScore))
+        }
+      }
+    } else {
+      result(PluginError.notSupportedForThisOSVersion.flutterError())
+    }
+  }
+
+  func getPlayerScoreObject(leaderboardID: String, span: Int, leaderboardCollection: Int, result: @escaping FlutterResult) {
+    if #available(iOS 14.0, *) {
+      Task {
+        do {
+          let leaderboards = try await GKLeaderboard.loadLeaderboards(IDs: [leaderboardID])
+          guard let leaderboard = leaderboards.first else {
+            result(PluginError.failedToGetScore.flutterError())
+            return
+          }
+          let response = try await leaderboard.loadEntries(for: [currentPlayer],
+                                                                 timeScope: GKLeaderboard.TimeScope(rawValue: span) ?? .allTime)
+     
+          let (localPlayerEntry, _) = response
+          
+          if let localPlayerEntry {
+            #if os(macOS)
+            let imageData = try? await localPlayerEntry.player.loadPhoto(for: .normal).tiffRepresentation
+            #else
+            let imageData = try? await localPlayerEntry.player.loadPhoto(for: .normal).pngData()
+            #endif
+            let scoreHolderIconImage = imageData?.base64EncodedString()
+            let score = LeaderboardScoreData(rank: localPlayerEntry.rank,
+                                              displayScore: localPlayerEntry.formattedScore,
+                                              rawScore: localPlayerEntry.score,
+                                              timestampMillis: Int(localPlayerEntry.date.timeIntervalSince1970),
+                                              scoreHolder: PlayerData(
+                                                displayName: localPlayerEntry.player.displayName,
+                                                playerID: localPlayerEntry.player.gamePlayerID,
+                                                teamPlayerID: localPlayerEntry.player.teamPlayerID,
+                                                iconImage: scoreHolderIconImage
+                                              ),
+                                              token: String(localPlayerEntry.context))
+            
+            if let data = try? JSONEncoder().encode(score) {
+              let string = String(data: data, encoding: String.Encoding.utf8)
+              result(string)
+            } else {
+              result(PluginError.failedToGetScore.flutterError())
+            }
+          } else {
+            result(PluginError.failedToGetScore.flutterError())
+          }
         } catch {
           result(error.flutterError(code: .failedToGetScore))
         }
@@ -70,9 +122,12 @@ class Leaderboards: BaseGamesServices {
                                               rawScore: item.score,
                                               timestampMillis: Int(item.date.timeIntervalSince1970),
                                               scoreHolder: PlayerData(
-                                                displayName: item.player.displayName, playerID: item.player.gamePlayerID, teamPlayerID: item.player.teamPlayerID,
+                                                displayName: item.player.displayName, 
+                                                playerID: item.player.gamePlayerID, 
+                                                teamPlayerID: item.player.teamPlayerID,
                                                 iconImage: scoreHolderIconImage
-                                              )))
+                                              ),
+                                              token: String(item.context)))
           }
           if let data = try? JSONEncoder().encode(items) {
             let string = String(data: data, encoding: String.Encoding.utf8)

--- a/games_services/darwin/Classes/Models/LeaderboardScoreData.swift
+++ b/games_services/darwin/Classes/Models/LeaderboardScoreData.swift
@@ -5,4 +5,5 @@ struct LeaderboardScoreData: Codable {
   var rawScore: Int
   var timestampMillis: Int
   var scoreHolder: PlayerData
+  var token: String?
 }

--- a/games_services/darwin/Classes/Models/Method.swift
+++ b/games_services/darwin/Classes/Models/Method.swift
@@ -11,6 +11,7 @@ enum Method: String {
   case getPlayerHiResImage = "getPlayerHiResImage"
   case getPlayerIconImage = "getPlayerIconImage"
   case getPlayerScore = "getPlayerScore"
+  case getPlayerScoreObject = "getPlayerScoreObject"
   case playerIsUnderage = "playerIsUnderage"
   case playerIsMultiplayerGamingRestricted = "playerIsMultiplayerGamingRestricted"
   case playerIsPersonalizedCommunicationRestricted = "playerIsPersonalizedCommunicationRestricted"
@@ -22,5 +23,6 @@ enum Method: String {
   case getSavedGames = "getSavedGames"
   case deleteGame = "deleteGame"
   case loadAchievements = "loadAchievements"
+  case resetAchievements = "resetAchievements"
   case loadLeaderboardScores = "loadLeaderboardScores"
 }

--- a/games_services/darwin/Classes/SwiftGamesServicesPlugin.swift
+++ b/games_services/darwin/Classes/SwiftGamesServicesPlugin.swift
@@ -33,16 +33,27 @@ public class SwiftGamesServicesPlugin: NSObject, FlutterPlugin {
       achievements.loadAchievements(result: result)
     case .showAchievements:
       achievements.showAchievements(result: result)
+    case .resetAchievements:
+      achievements.resetAchievements(result: result)    
     case .unlock:
       let achievementID = (arguments?["achievementID"] as? String) ?? ""
       let percentComplete = (arguments?["percentComplete"] as? Double) ?? 0.0
-      achievements.report(achievementID: achievementID, percentComplete: percentComplete, result: result)
+      let showsCompletionBanner = (arguments?["showsCompletionBanner"] as? Bool) ?? true
+      achievements.report(achievementID: achievementID, percentComplete: percentComplete, showsCompletionBanner: showsCompletionBanner, result: result)
     case .showLeaderboards:
       let leaderboardID = (arguments?["leaderboardID"] as? String) ?? ""
       leaderboards.showLeaderboardWith(identifier: leaderboardID, result: result)
     case .getPlayerScore:
       let leaderboardID = (arguments?["leaderboardID"] as? String) ?? ""
       leaderboards.getPlayerScore(leaderboardID: leaderboardID, result: result)
+    case .getPlayerScoreObject:
+      let leaderboardID = (arguments?["leaderboardID"] as? String) ?? ""
+      let span = (arguments?["span"] as? Int) ?? 0
+      let leaderboardCollection = (arguments?["leaderboardCollection"] as? Int) ?? 0
+      leaderboards.getPlayerScoreObject(leaderboardID: leaderboardID,
+                            span: span,
+                            leaderboardCollection: leaderboardCollection,
+                            result: result)      
     case .loadLeaderboardScores:
       let leaderboardID = (arguments?["leaderboardID"] as? String) ?? ""
       let span = (arguments?["span"] as? Int) ?? 0
@@ -56,7 +67,8 @@ public class SwiftGamesServicesPlugin: NSObject, FlutterPlugin {
     case .submitScore:
       let leaderboardID = (arguments?["leaderboardID"] as? String) ?? ""
       let score = (arguments?["value"] as? Int) ?? 0
-      leaderboards.report(score: score, leaderboardID: leaderboardID, result: result)
+      let token = (arguments?["token"] as? String) ?? ""
+      leaderboards.report(score: score, leaderboardID: leaderboardID, token: token, result: result)
     case .hideAccessPoint:
       player.hideAccessPoint(result: result)
     case .showAccessPoint:

--- a/games_services/darwin/Classes/Util/Error.swift
+++ b/games_services/darwin/Classes/Util/Error.swift
@@ -41,6 +41,8 @@ enum PluginError: String {
       return "Failed to delete saved game"
     case  .failedToLoadAchievements:
       return "Failed to get the achievements list"
+    case .failedToResetAchievements: 
+      return "Failed to reset achievements"      
     case .failedToLoadLeaderboardScores:
       return "Failed to load leaderboard scores"
     }
@@ -58,6 +60,7 @@ enum PluginError: String {
   case failedToGetSavedGames = "failed_to_get_saved_games"
   case failedToDeleteSavedGame = "failed_to_delete_saved_game"
   case failedToLoadAchievements = "failed_to_load_achievements"
+  case failedToResetAchievements = "failed_to_reset_achievements"
   case failedToLoadLeaderboardScores = "failed_to_load_leaderboard_scores"
 
   func flutterError() -> FlutterError {

--- a/games_services/example/lib/main.dart
+++ b/games_services/example/lib/main.dart
@@ -74,6 +74,10 @@ class AppState extends State<App> {
                           child: const Text('Load Achievement'),
                         ),
                         ElevatedButton(
+                          onPressed: _resetAchievement,
+                          child: const Text('Reset Achievement'),
+                        ),
+                        ElevatedButton(
                           onPressed: _loadLeaderboardScores,
                           child: const Text('Load Leaderboard Scores'),
                         ),
@@ -97,6 +101,10 @@ class AppState extends State<App> {
                         ElevatedButton(
                           onPressed: _getPlayerScore,
                           child: const Text('Get player score'),
+                        ),
+                        ElevatedButton(
+                          onPressed: _getPlayerScoreObject,
+                          child: const Text('Load Player Centered Scores'),
                         ),
                         ElevatedButton(
                           onPressed: _getPlayerName,
@@ -153,6 +161,15 @@ class AppState extends State<App> {
     print(result);
   }
 
+  void _getPlayerScoreObject() async {
+    final result = await Leaderboards.getPlayerScoreObject(
+        iOSLeaderboardID: "ios_leaderboard_id",
+        androidLeaderboardID: "android_leaderboard_id",
+        scope: PlayerScope.global,
+        timeScope: TimeScope.allTime);
+    print(result);
+  }
+
   void _showAccessPoint() async {
     final result = await Player.showAccessPoint(AccessPointLocation.topLeading);
     print(result);
@@ -160,6 +177,11 @@ class AppState extends State<App> {
 
   void _hideAccessPoint() async {
     final result = await Player.hideAccessPoint();
+    print(result);
+  }
+
+  void _resetAchievement() async {
+    final result = await Achievements.resetAchievements();
     print(result);
   }
 

--- a/games_services/lib/games_services.dart
+++ b/games_services/lib/games_services.dart
@@ -5,6 +5,7 @@ export 'src/player.dart';
 export 'src/save_game.dart';
 export 'src/models/achievement_item_data.dart';
 export 'src/models/saved_game.dart';
+export 'src/models/player_data.dart';
 export 'src/models/leaderboard_score_data.dart';
 
 export 'src/games_services.dart';

--- a/games_services/lib/src/achievements.dart
+++ b/games_services/lib/src/achievements.dart
@@ -22,6 +22,11 @@ abstract class Achievements {
     return null;
   }
 
+  /// It will reset the achievements.
+  static Future<String?> resetAchievements() async {
+    return await GamesServicesPlatform.instance.resetAchievements();
+  }
+
   /// Unlock an [achievement].
   /// [Achievement] takes three parameters:
   /// [androidID] the achievement ID for Google Play Games.

--- a/games_services/lib/src/games_services.dart
+++ b/games_services/lib/src/games_services.dart
@@ -35,12 +35,18 @@ class GamesServices {
     return await Achievements.loadAchievements();
   }
 
+  /// It will reset the achievements.
+  static Future<String?> resetAchievements() async {
+    return await Achievements.resetAchievements();
+  }
+
   /// Unlock an [achievement].
   /// [Achievement] takes three parameters:
   /// [androidID] the achievement ID for Google Play Games.
   /// [iOSID] the achievement ID for Game Center.
   /// [percentComplete] the completion percentage of the achievement,
   /// this parameter is optional on iOS/macOS.
+  /// [showsCompletionBanner] for iOS only, defaults to true
   static Future<String?> unlock({required Achievement achievement}) async {
     return await Achievements.unlock(achievement: achievement);
   }

--- a/games_services/lib/src/leaderboards.dart
+++ b/games_services/lib/src/leaderboards.dart
@@ -36,6 +36,21 @@ abstract class Leaderboards {
     return null;
   }
 
+  /// Get leaderboard scores as a list for current player
+  static Future<LeaderboardScoreData>? getPlayerScoreObject(
+      {iOSLeaderboardID = "",
+      androidLeaderboardID = "",
+      required PlayerScope scope,
+      required TimeScope timeScope}) async {
+    final String? response = await GamesServicesPlatform.instance.getPlayerScoreObject(
+        androidLeaderboardID: androidLeaderboardID,
+        iOSLeaderboardID: iOSLeaderboardID,
+        scope: scope,
+        timeScope: timeScope);
+
+    return LeaderboardScoreData.fromJson(json.decode(response ?? ""));
+  }
+
   /// Submit a [score] to specific leaderboard.
   /// [Score] takes three parameters:
   /// [androidLeaderboardID] the leaderboard ID for Google Play Games.

--- a/games_services/lib/src/models/leaderboard_score_data.dart
+++ b/games_services/lib/src/models/leaderboard_score_data.dart
@@ -6,6 +6,7 @@ class LeaderboardScoreData {
   final int rawScore;
   final int timestampMillis;
   final PlayerData scoreHolder;
+  final String? token;
 
   // provided to maintain backwards compatibility
   @Deprecated('Use scoreHolder.displayName instead.')
@@ -13,13 +14,13 @@ class LeaderboardScoreData {
   @Deprecated('Use scoreHolder.iconImage instead.')
   String? get scoreHolderIconImage => scoreHolder.iconImage;
 
-  const LeaderboardScoreData({
-    required this.rank,
-    required this.displayScore,
-    required this.rawScore,
-    required this.timestampMillis,
-    required this.scoreHolder,
-  });
+  const LeaderboardScoreData(
+      {required this.rank,
+      required this.displayScore,
+      required this.rawScore,
+      required this.timestampMillis,
+      required this.scoreHolder,
+      this.token});
 
   factory LeaderboardScoreData.fromJson(Map<String, dynamic> json) {
     return LeaderboardScoreData(
@@ -28,6 +29,7 @@ class LeaderboardScoreData {
       rawScore: json["rawScore"],
       timestampMillis: json["timestampMillis"],
       scoreHolder: PlayerData.fromJson(json["scoreHolder"]),
+      token: (json["token"] as String?)?.replaceAll("\n", ""),
     );
   }
 }

--- a/games_services/pubspec.yaml
+++ b/games_services/pubspec.yaml
@@ -13,9 +13,9 @@ dependencies:
   flutter:
     sdk: flutter
 
-  games_services_platform_interface: ^4.0.1
-    # path: ../games_services_platform_interface/
-    # uncomment in time of development.
+  games_services_platform_interface: #^4.0.1
+    path: ../games_services_platform_interface/
+    #uncomment in time of development.
     # git:
     #   url: https://github.com/Abedalkareem/games_services
     #   path: games_services_platform_interface

--- a/games_services_platform_interface/lib/game_services_platform_interface.dart
+++ b/games_services_platform_interface/lib/game_services_platform_interface.dart
@@ -72,6 +72,11 @@ abstract class GamesServicesPlatform extends PlatformInterface {
     throw UnimplementedError("not implemented.");
   }
 
+  /// Reset achievements.
+  Future<String?> resetAchievements() async {
+    throw UnimplementedError("not implemented.");
+  }
+
   /// Get leaderboard scores as json data.
   /// To show the device's default leaderboards screen use [showLeaderboards].
   Future<String?> loadLeaderboardScores(
@@ -80,6 +85,16 @@ abstract class GamesServicesPlatform extends PlatformInterface {
       required PlayerScope scope,
       required TimeScope timeScope,
       required int maxResults}) async {
+    throw UnimplementedError("not implemented.");
+  }
+
+  /// Get leaderboard scores as a json data for current player.
+  /// To show the prebuilt system screen use [showLeaderboards].
+  Future<String?> getPlayerScoreObject(
+      {iOSLeaderboardID = "",
+      androidLeaderboardID = "",
+      required PlayerScope scope,
+      required TimeScope timeScope}) async {
     throw UnimplementedError("not implemented.");
   }
 

--- a/games_services_platform_interface/lib/src/game_services_platform_impl.dart
+++ b/games_services_platform_interface/lib/src/game_services_platform_impl.dart
@@ -18,15 +18,14 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
     return await _channel.invokeMethod("unlock", {
       "achievementID": achievement.id,
       "percentComplete": achievement.percentComplete,
+      "showsCompletionBanner": achievement.showsCompletionBanner
     });
   }
 
   @override
   Future<String?> submitScore({required Score score}) async {
-    return await _channel.invokeMethod("submitScore", {
-      "leaderboardID": score.leaderboardID,
-      "value": score.value,
-    });
+    return await _channel.invokeMethod(
+        "submitScore", {"leaderboardID": score.leaderboardID, "value": score.value, "token": score.token});
   }
 
   @override
@@ -57,6 +56,11 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
   }
 
   @override
+  Future<String?> resetAchievements() async {
+    return await _channel.invokeMethod("resetAchievements");
+  }
+
+  @override
   Future<String?> loadLeaderboardScores(
       {iOSLeaderboardID = "",
       androidLeaderboardID = "",
@@ -78,6 +82,19 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
     return await _channel.invokeMethod("getPlayerScore", {
       "leaderboardID":
           Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID
+    });
+  }
+
+  @override
+  Future<String?> getPlayerScoreObject(
+      {iOSLeaderboardID = "",
+      androidLeaderboardID = "",
+      required PlayerScope scope,
+      required TimeScope timeScope}) async {
+    return await _channel.invokeMethod("getPlayerScoreObject", {
+      "leaderboardID": Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID,
+      "leaderboardCollection": scope.value,
+      "span": timeScope.value
     });
   }
 

--- a/games_services_platform_interface/lib/src/models/achievement.dart
+++ b/games_services_platform_interface/lib/src/models/achievement.dart
@@ -3,6 +3,7 @@ import '../util/device.dart';
 class Achievement {
   String? androidID;
   String iOSID;
+  bool showsCompletionBanner;
   double percentComplete;
   int steps;
 
@@ -11,8 +12,5 @@ class Achievement {
   }
 
   Achievement(
-      {this.androidID,
-      this.iOSID = "",
-      this.percentComplete = 100,
-      this.steps = 0});
+      {this.androidID, this.iOSID = "", this.showsCompletionBanner = true, this.percentComplete = 100, this.steps = 0});
 }

--- a/games_services_platform_interface/lib/src/models/score.dart
+++ b/games_services_platform_interface/lib/src/models/score.dart
@@ -4,10 +4,11 @@ class Score {
   String? androidLeaderboardID;
   String? iOSLeaderboardID;
   int? value;
+  String? token;
 
   String? get leaderboardID {
     return Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID;
   }
 
-  Score({this.iOSLeaderboardID, this.androidLeaderboardID, this.value});
+  Score({this.iOSLeaderboardID, this.androidLeaderboardID, this.value, this.token});
 }


### PR DESCRIPTION
A user requested the ability to retrieve a players score rank. I had previously modified this package locally to add methods to do that, and it has been live for almost a year in my app. I have modified my local update to incorporate the latest change to use `PlayerData` and am offering up the code here (plus some other enhancements) for you to pull apart, change and incorporate if you wish! Details below:

- Add `getPlayerScoreObject` to retrieve rank and other score data for leaderboard and time span
- Added optional String `token` to methods that submit and retrieve score. Can be used to store additional information or metadata about the score. Saved as `scoreTag` (String) on Android, `context` (Int) on iOS. Due to the difference in datatype between Android / iOS, I decided that while Int was 'safer' as the type (compatible with both), String offers more for Android only-implementations, and a documented note for iOS users to use Int converted to String would suffice
- Added optional Bool `showsCompletionBanner` as parameter for report achievement, replacing hard-coded true. Defaults to true
- Added `resetAchievements` method for iOS only, Android doesn't support this through Play Games
- Update play-services-games version
- Update play-services-auth version