### PR TITLE
Add `playerCentered` option to `loadLeaderboards`.

### DIFF
--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
@@ -126,10 +126,11 @@ class GamesServicesPlugin : FlutterPlugin,
       }
       Method.LoadLeaderboardScores -> {
         val leaderboardID = call.argument<String>("leaderboardID") ?: ""
+        val playerCentered = call.argument<Boolean>("playerCentered") ?: false
         val span = call.argument<Int>("span") ?: 0
         val leaderboardCollection = call.argument<Int>("leaderboardCollection") ?: 0
         val maxResults = call.argument<Int>("maxResults") ?: 0
-        leaderboards?.loadLeaderboardScores(activity, leaderboardID, span, leaderboardCollection, maxResults, result)
+        leaderboards?.loadLeaderboardScores(activity, leaderboardID, playerCentered, span, leaderboardCollection, maxResults, result)
       }
       Method.SubmitScore -> {
         val leaderboardID = call.argument<String>("leaderboardID") ?: ""

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Leaderboards.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Leaderboards.kt
@@ -33,6 +33,7 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) :
 
   // used to retry [loadLeaderboardScore] after being granted friends list access
   private var leaderboardID: String? = null;
+  private var playerCentered: Boolean? = null;
   private var span: Int? = null;
   private var leaderboardCollection: Int? = null;
   private var maxResults: Int? = null;
@@ -48,6 +49,7 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) :
         loadLeaderboardScores(
           activityPluginBinding.activity,
           leaderboardID!!,
+          playerCentered!!,
           span!!,
           leaderboardCollection!!,
           maxResults!!,
@@ -61,6 +63,7 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) :
         )
       }
       leaderboardID = null
+      playerCentered = null
       span = null
       leaderboardCollection = null
       maxResults = null
@@ -97,13 +100,15 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) :
   fun loadLeaderboardScores(
     activity: Activity?,
     leaderboardID: String,
+    playerCentered: Boolean,
     span: Int,
     leaderboardCollection: Int,
     maxResults: Int,
     result: MethodChannel.Result
   ) {
     activity ?: return
-    leaderboardsClient.loadTopScores(leaderboardID, span, leaderboardCollection, maxResults)
+    (if (playerCentered) leaderboardsClient.loadPlayerCenteredScores(leaderboardID, span, leaderboardCollection, maxResults)
+        else leaderboardsClient.loadTopScores(leaderboardID, span, leaderboardCollection, maxResults))
       .addOnSuccessListener { annotatedData ->
         val data = annotatedData.get()
 
@@ -153,6 +158,7 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) :
         // handle friends list CONSENT_REQUIRED error to trigger permission request dialog
         if (it is FriendsResolutionRequiredException) {
           this.leaderboardID = leaderboardID
+          this.playerCentered = playerCentered
           this.span = span
           this.leaderboardCollection = leaderboardCollection
           this.maxResults = maxResults

--- a/games_services/darwin/Classes/SwiftGamesServicesPlugin.swift
+++ b/games_services/darwin/Classes/SwiftGamesServicesPlugin.swift
@@ -56,10 +56,12 @@ public class SwiftGamesServicesPlugin: NSObject, FlutterPlugin {
                             result: result)      
     case .loadLeaderboardScores:
       let leaderboardID = (arguments?["leaderboardID"] as? String) ?? ""
+      let playerCentered = (arguments?["playerCentered"] as? Bool) ?? false
       let span = (arguments?["span"] as? Int) ?? 0
       let leaderboardCollection = (arguments?["leaderboardCollection"] as? Int) ?? 0
       let maxResults = (arguments?["maxResults"] as? Int) ?? 10
       leaderboards.loadLeaderboardScores(leaderboardID: leaderboardID,
+                            playerCentered: playerCentered,
                             span: span,
                             leaderboardCollection: leaderboardCollection,
                             maxResults: maxResults,

--- a/games_services/lib/src/leaderboards.dart
+++ b/games_services/lib/src/leaderboards.dart
@@ -20,16 +20,17 @@ abstract class Leaderboards {
   static Future<List<LeaderboardScoreData>?> loadLeaderboardScores(
       {iOSLeaderboardID = "",
       androidLeaderboardID = "",
+      bool playerCentered = false,
       required PlayerScope scope,
       required TimeScope timeScope,
       required int maxResults}) async {
     final response = await GamesServicesPlatform.instance.loadLeaderboardScores(
-      androidLeaderboardID: androidLeaderboardID,
-      iOSLeaderboardID: iOSLeaderboardID,
-      scope: scope,
-      timeScope: timeScope,
-      maxResults: maxResults,
-    );
+        androidLeaderboardID: androidLeaderboardID,
+        iOSLeaderboardID: iOSLeaderboardID,
+        playerCentered: playerCentered,
+        scope: scope,
+        timeScope: timeScope,
+        maxResults: maxResults);
     if (response != null) {
       Iterable items = json.decode(response) as List;
       return List<LeaderboardScoreData>.from(
@@ -44,13 +45,12 @@ abstract class Leaderboards {
       androidLeaderboardID = "",
       required PlayerScope scope,
       required TimeScope timeScope}) async {
-    final String? response =
-        await GamesServicesPlatform.instance.getPlayerScoreObject(
-      androidLeaderboardID: androidLeaderboardID,
-      iOSLeaderboardID: iOSLeaderboardID,
-      scope: scope,
-      timeScope: timeScope,
-    );
+    final String? response = await GamesServicesPlatform.instance
+        .getPlayerScoreObject(
+            androidLeaderboardID: androidLeaderboardID,
+            iOSLeaderboardID: iOSLeaderboardID,
+            scope: scope,
+            timeScope: timeScope);
 
     return LeaderboardScoreData.fromJson(json.decode(response ?? ""));
   }

--- a/games_services/pubspec.lock
+++ b/games_services/pubspec.lock
@@ -33,10 +33,9 @@ packages:
   games_services_platform_interface:
     dependency: "direct main"
     description:
-      name: games_services_platform_interface
-      sha256: "3742c23afdd5ebd5498612b13dc251853fccf935f6f56ef6bf13c6e8c0c89a8d"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../games_services_platform_interface"
+      relative: true
+    source: path
     version: "4.0.2"
   lints:
     dependency: transitive

--- a/games_services/pubspec.yaml
+++ b/games_services/pubspec.yaml
@@ -13,8 +13,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  games_services_platform_interface: ^4.0.2
-    #path: ../games_services_platform_interface/
+  games_services_platform_interface: # ^4.0.2
+    path: ../games_services_platform_interface/
     #uncomment in time of development.
     # git:
     #   url: https://github.com/Abedalkareem/games_services

--- a/games_services_platform_interface/lib/game_services_platform_interface.dart
+++ b/games_services_platform_interface/lib/game_services_platform_interface.dart
@@ -82,6 +82,7 @@ abstract class GamesServicesPlatform extends PlatformInterface {
   Future<String?> loadLeaderboardScores(
       {iOSLeaderboardID = "",
       androidLeaderboardID = "",
+      bool playerCentered = false,
       required PlayerScope scope,
       required TimeScope timeScope,
       required int maxResults}) async {

--- a/games_services_platform_interface/lib/src/game_services_platform_impl.dart
+++ b/games_services_platform_interface/lib/src/game_services_platform_impl.dart
@@ -24,8 +24,11 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
 
   @override
   Future<String?> submitScore({required Score score}) async {
-    return await _channel.invokeMethod(
-        "submitScore", {"leaderboardID": score.leaderboardID, "value": score.value, "token": score.token});
+    return await _channel.invokeMethod("submitScore", {
+      "leaderboardID": score.leaderboardID,
+      "value": score.value,
+      "token": score.token
+    });
   }
 
   @override
@@ -64,12 +67,14 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
   Future<String?> loadLeaderboardScores(
       {iOSLeaderboardID = "",
       androidLeaderboardID = "",
+      bool playerCentered = false,
       required PlayerScope scope,
       required TimeScope timeScope,
       required int maxResults}) async {
     return await _channel.invokeMethod("loadLeaderboardScores", {
       "leaderboardID":
           Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID,
+      "playerCentered": playerCentered,
       "leaderboardCollection": scope.value,
       "span": timeScope.value,
       "maxResults": maxResults
@@ -92,7 +97,8 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
       required PlayerScope scope,
       required TimeScope timeScope}) async {
     return await _channel.invokeMethod("getPlayerScoreObject", {
-      "leaderboardID": Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID,
+      "leaderboardID":
+          Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID,
       "leaderboardCollection": scope.value,
       "span": timeScope.value
     });


### PR DESCRIPTION
When retrieving leaderboards via the `loadLeaderboards` method, devs may wish to center the results around the player's ranking. To provide this functionality, we can add a `playerCentered` parameter to the method call.

GPG provides a method `loadPlayerCenteredScores` so we simply call the correct method based on the value of `playerCentered`.

GK does not provide a specific method for this, but we can find the player's rank via `loadEntries(for: currentPlayer)` and use the resulting `localPlayer.rank` to calculate the `NSRange` to pass to the subsequent `loadEntries` call.

Both implementations return the top scores if the user does not have an entry on the leaderboard.