### PR TITLE
Update Android Gradle Plugin to 8.5.2 and Cleanup Project Configuration

### DIFF
--- a/games_services/android/build.gradle
+++ b/games_services/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:8.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.4.2'
     }
@@ -26,21 +26,30 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    if (project.android.hasProperty('namespace')) {
-        namespace 'com.abedalkareem.games_services'
-    }
+    namespace 'com.abedalkareem.games_services'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
+
     defaultConfig {
         compileSdk 34
         minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "proguard-rules.pro"
     }
+
     lintOptions {
         disable 'InvalidPackage'
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
     }
 }
 

--- a/games_services/android/gradle.properties
+++ b/games_services/android/gradle.properties
@@ -13,4 +13,3 @@
 #Fri Jun 04 15:31:11 CEST 2021
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true

--- a/games_services/android/gradle/wrapper/gradle-wrapper.properties
+++ b/games_services/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Aug 11 13:19:46 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/games_services/example/android/app/build.gradle
+++ b/games_services/example/android/app/build.gradle
@@ -53,8 +53,18 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+
     lint {
         disable 'InvalidPackage'
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
     }
 }
 

--- a/games_services/example/android/app/src/debug/AndroidManifest.xml
+++ b/games_services/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.abedalkareem.games_services_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/games_services/example/android/app/src/profile/AndroidManifest.xml
+++ b/games_services/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.abedalkareem.games_services_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/games_services/example/android/build.gradle
+++ b/games_services/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.1'
+        classpath 'com.android.tools.build:gradle:8.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -15,11 +15,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-    }
-    tasks.withType(JavaCompile).configureEach {
-        javaCompiler = javaToolchains.compilerFor {
-            languageVersion = JavaLanguageVersion.of(8)
-        }
     }
 }
 
@@ -31,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/games_services/example/android/gradle.properties
+++ b/games_services/example/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
-android.enableJetifier=true

--- a/games_services/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/games_services/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat May 13 15:11:27 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/games_services/gradle.properties
+++ b/games_services/gradle.properties
@@ -1,2 +1,0 @@
-android.enableJetifier=true
-android.useAndroidX=true


### PR DESCRIPTION
This pull request includes several updates and cleanups to improve the project configuration:

- **Android Gradle plugin update**: 
  - Upgraded the Android Gradle Plugin to version **8.5.2** for both the library and example projects.
  - Updated Gradle to the required version for compatibility.

- **disabled Jetifier**: 
  - Disabled Jetifier, as it is no longer needed.

- **gradle.properties cleanup**: 
  - Removed an unused gradle.properties file to streamline the project configuration.

- **build.gradle updates**:
  - Updated the build.gradle files to align with the new Android Gradle Plugin version:
    - Set **Java source compatibility** to **Java 17**.
    - Updated **Kotlin options** to use **JVM target 17**.