### PR TITLE
Remove Google Auth api dependency.

### DIFF
--- a/games_services/android/build.gradle
+++ b/games_services/android/build.gradle
@@ -47,6 +47,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'com.google.code.gson:gson:2.10.1'
-    api "com.google.android.gms:play-services-games-v2:20.1.2"
-    api 'com.google.android.gms:play-services-auth:21.2.0'
+    implementation "com.google.android.gms:play-services-games-v2:20.1.2"
 }

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Auth.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Auth.kt
@@ -8,16 +8,14 @@ import com.abedalkareem.games_services.models.PendingOperation
 import com.abedalkareem.games_services.models.value
 import com.abedalkareem.games_services.util.PluginError
 import com.abedalkareem.games_services.util.errorCode
-import com.google.android.gms.auth.api.Auth
 import com.google.android.gms.games.AuthenticationResult
 import com.google.android.gms.games.PlayGames
 import com.google.android.gms.tasks.Task
 import io.flutter.plugin.common.MethodChannel
-import io.flutter.plugin.common.PluginRegistry
 
 private const val RC_SIGN_IN = 9000
 
-class Auth : PluginRegistry.ActivityResultListener {
+class Auth {
 
   private var pendingOperation: PendingOperation? = null
 
@@ -70,26 +68,6 @@ class Auth : PluginRegistry.ActivityResultListener {
     Log.i(pendingOperation?.method, "error")
     pendingOperation?.result?.error(errorCode, errorMessage, null)
     pendingOperation = null
-  }
-  //endregion
-
-  //region ActivityResultListener
-  override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
-    if (requestCode == RC_SIGN_IN) {
-      val result = data?.let { Auth.GoogleSignInApi.getSignInResultFromIntent(it) }
-      val signInAccount = result?.signInAccount
-      if (result?.isSuccess == true && signInAccount != null) {
-        handleSignInResult(pendingOperation?.activity)
-      } else {
-        var message = result?.status?.statusMessage ?: ""
-        if (message.isEmpty()) {
-          message = "Something went wrong " + result?.status
-        }
-        finishPendingOperationWithError(PluginError.FailedToAuthenticate.errorCode(), message)
-      }
-      return true
-    }
-    return false
   }
   //endregion
 }

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
@@ -51,7 +51,6 @@ class GamesServicesPlugin : FlutterPlugin,
 
   //region ActivityAware
   private fun disposeActivity() {
-    activityPluginBinding?.removeActivityResultListener(auth)
     activityPluginBinding = null
     leaderboards = null
     achievements = null
@@ -78,7 +77,6 @@ class GamesServicesPlugin : FlutterPlugin,
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
     activityPluginBinding = binding
     activity = binding.activity
-    binding.addActivityResultListener(auth)
     init()
   }
 


### PR DESCRIPTION
After reviewing the code, it seems that the auth api is no longer necessary after migrating to GPG v2. This removes the dependency on the library as well cleaning up the Auth class, removing the sign in result listener redundancy. This may even resolve some reported issues related to the sign in process/result.