### PR TITLE
Add PlayerData to proguard-rules.

### DIFF
--- a/games_services/android/proguard-rules.pro
+++ b/games_services/android/proguard-rules.pro
@@ -1,3 +1,4 @@
 -keep class com.abedalkareem.games_services.models.AchievementItemData { <fields>; }
 -keep class com.abedalkareem.games_services.models.LeaderboardScoreData { <fields>; }
 -keep class com.abedalkareem.games_services.models.SavedGame { <fields>; }
+-keep class com.abedalkareem.games_services.models.PlayerData { <fields>; }


### PR DESCRIPTION
Fixes #171.

 PlayerData Gson breaks on release build without this.