### PR TITLE
Add optional `forceRefresh` parameters to load methods on Android.

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -13,5 +13,13 @@ Sign the user into Game Center (iOS/macOS) or Google Play Games (Android). This 
 A boolean value to check if the user is currently signed into Game Center or Google Play Games.
 
 ```dart
-final isSignedIn = GameAuth.isSignedIn;
+final isSignedIn = await GameAuth.isSignedIn;
+```
+
+## Get Auth Code
+
+Retrieve a Google Play Games `server_auth_code` to be used by a backend, such as Firebase, to authenticate the user. `null` on other platforms.
+
+```dart
+final authCode = await GameAuth.getAuthCode(String clientID);
 ```

--- a/docs/leaderboard_and_achievements.md
+++ b/docs/leaderboard_and_achievements.md
@@ -57,6 +57,8 @@ Get leaderboard scores as a list. Use this to build a custom UI.
 final result = await Leaderboards.loadLeaderboardScores(
         iOSLeaderboardID: "ios_leaderboard_id",
         androidLeaderboardID: "android_leaderboard_id",
+        // Returns a list centered around the player's rank on the leaderboard. (Defaults to false)
+        playerCentered: false,
         scope: PlayerScope.global,
         timeScope: TimeScope.allTime,
         maxResults: 10);

--- a/docs/player.md
+++ b/docs/player.md
@@ -16,6 +16,18 @@ Get the current player's name. This returns the player's alias on iOS/macOS.
 final playerName = Player.getPlayerName();
 ```
 
+## Player icon image
+
+Get the player's icon image as a base64 encoded string.
+
+```dart
+// icon-size image
+final base64iconImage = await Player.getPlayerIconImage();
+
+// hi-res image
+final base64hiResImage = await Player.getPlayerHiResImage();
+```
+
 ## Player score
 
 Get the current player's score for a specific leaderboard.

--- a/docs/save_load_game.md
+++ b/docs/save_load_game.md
@@ -23,12 +23,6 @@ Enable saved games support for your game in the Google Play Console:
 - Turn the `Saved Games` option to `ON`.  
 - Click `Save`.
 
-After that when you sign in make sure to set `shouldEnableSavedGame` to `true`.
-
-``` dart
- GameAuth.signIn(shouldEnableSavedGame: true);
-```  
-
 ## Save game
 
 Save a game with `data` and a unique `name`.

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Achievements.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Achievements.kt
@@ -62,10 +62,10 @@ class Achievements(private var activityPluginBinding: ActivityPluginBinding) {
       }
   }
 
-  fun loadAchievements(activity: Activity?, result: MethodChannel.Result) {
+  fun loadAchievements(activity: Activity?, forceRefresh: Boolean, result: MethodChannel.Result) {
     activity ?: return
     achievementClient
-      .load(true)
+      .load(forceRefresh)
       .addOnSuccessListener { annotatedData ->
         val data = annotatedData.get()
 

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
@@ -171,7 +171,8 @@ class GamesServicesPlugin : FlutterPlugin,
         saveGame?.loadGame(name, result)
       }
       Method.GetSavedGames -> {
-        saveGame?.getSavedGames(result)
+        val forceRefresh = call.argument<Boolean>("forceRefresh") ?: false
+        saveGame?.getSavedGames(forceRefresh, result)
       }
       Method.DeleteGame -> {
         val name = call.argument<String>("name") ?: ""

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
@@ -107,7 +107,8 @@ class GamesServicesPlugin : FlutterPlugin,
         achievements?.showAchievements(activity, result)
       }
       Method.LoadAchievements -> {
-        achievements?.loadAchievements(activity, result)
+        val forceRefresh = call.argument<Boolean>("forceRefresh") ?: false
+        achievements?.loadAchievements(activity, forceRefresh, result)
       }
       Method.Unlock -> {
         val achievementID = call.argument<String>("achievementID") ?: ""

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
@@ -128,7 +128,8 @@ class GamesServicesPlugin : FlutterPlugin,
         val span = call.argument<Int>("span") ?: 0
         val leaderboardCollection = call.argument<Int>("leaderboardCollection") ?: 0
         val maxResults = call.argument<Int>("maxResults") ?: 0
-        leaderboards?.loadLeaderboardScores(activity, leaderboardID, playerCentered, span, leaderboardCollection, maxResults, result)
+        val forceRefresh = call.argument<Boolean>("forceRefresh") ?: false
+        leaderboards?.loadLeaderboardScores(activity, leaderboardID, playerCentered, span, leaderboardCollection, maxResults, forceRefresh, result)
       }
       Method.SubmitScore -> {
         val leaderboardID = call.argument<String>("leaderboardID") ?: ""

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Leaderboards.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Leaderboards.kt
@@ -32,13 +32,14 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) :
     }
 
   // used to retry [loadLeaderboardScore] after being granted friends list access
-  private var leaderboardID: String? = null;
-  private var playerCentered: Boolean? = null;
-  private var span: Int? = null;
-  private var leaderboardCollection: Int? = null;
-  private var maxResults: Int? = null;
-  private var result: MethodChannel.Result? = null;
-  private var errorMessage: String? = null;
+  private var leaderboardID: String? = null
+  private var playerCentered: Boolean? = null
+  private var span: Int? = null
+  private var leaderboardCollection: Int? = null
+  private var maxResults: Int? = null
+  private var forceRefresh: Boolean? = null
+  private var result: MethodChannel.Result? = null
+  private var errorMessage: String? = null
 
   // handle result from friends list permission request
   override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?): Boolean {
@@ -53,6 +54,7 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) :
           span!!,
           leaderboardCollection!!,
           maxResults!!,
+          forceRefresh!!,
           result!!
         )
       } else {
@@ -67,8 +69,9 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) :
       span = null
       leaderboardCollection = null
       maxResults = null
+      forceRefresh = null
       result = null
-      errorMessage = null;
+      errorMessage = null
       true
     } else {
       false
@@ -104,11 +107,12 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) :
     span: Int,
     leaderboardCollection: Int,
     maxResults: Int,
+    forceRefresh: Boolean,
     result: MethodChannel.Result
   ) {
     activity ?: return
-    (if (playerCentered) leaderboardsClient.loadPlayerCenteredScores(leaderboardID, span, leaderboardCollection, maxResults)
-        else leaderboardsClient.loadTopScores(leaderboardID, span, leaderboardCollection, maxResults))
+    (if (playerCentered) leaderboardsClient.loadPlayerCenteredScores(leaderboardID, span, leaderboardCollection, maxResults, forceRefresh)
+        else leaderboardsClient.loadTopScores(leaderboardID, span, leaderboardCollection, maxResults, forceRefresh))
       .addOnSuccessListener { annotatedData ->
         val data = annotatedData.get()
 
@@ -162,6 +166,7 @@ class Leaderboards(private var activityPluginBinding: ActivityPluginBinding) :
           this.span = span
           this.leaderboardCollection = leaderboardCollection
           this.maxResults = maxResults
+          this.forceRefresh = forceRefresh
           this.result = result
           this.errorMessage = it.localizedMessage
           val pendingIntent = it.resolution

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/SaveGame.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/SaveGame.kt
@@ -21,9 +21,9 @@ class SaveGame(private var activityPluginBinding: ActivityPluginBinding) {
       return PlayGames.getSnapshotsClient(activityPluginBinding.activity)
     }
 
-  fun getSavedGames(result: MethodChannel.Result) {
+  fun getSavedGames(forceRefresh: Boolean, result: MethodChannel.Result) {
     Log.d(tag, "[GetSavedGames] Start loading all saved games")
-    snapshotsClient.load(true)
+    snapshotsClient.load(forceRefresh)
       .addOnSuccessListener { annotatedData ->
 
         val gson = Gson()

--- a/games_services/lib/src/achievements.dart
+++ b/games_services/lib/src/achievements.dart
@@ -27,7 +27,7 @@ abstract class Achievements {
     return null;
   }
 
-  /// It will reset the achievements.
+  /// It will reset the achievements. Not available on Android.
   static Future<String?> resetAchievements() async {
     return await GamesServicesPlatform.instance.resetAchievements();
   }

--- a/games_services/lib/src/achievements.dart
+++ b/games_services/lib/src/achievements.dart
@@ -12,8 +12,13 @@ abstract class Achievements {
 
   /// Get achievements as a list. Use this to build a custom UI.
   /// To show the device's default achievements screen use [showAchievements].
-  static Future<List<AchievementItemData>?> loadAchievements() async {
-    final response = await GamesServicesPlatform.instance.loadAchievements();
+  ///
+  /// The `forceRefresh` argument will invalidate the cache on Android, fetching
+  /// the latest results. It has no affect on iOS.
+  static Future<List<AchievementItemData>?> loadAchievements(
+      {bool forceRefresh = false}) async {
+    final response = await GamesServicesPlatform.instance
+        .loadAchievements(forceRefresh: forceRefresh);
     if (response != null) {
       Iterable items = json.decode(response) as List;
       return List<AchievementItemData>.from(

--- a/games_services/lib/src/games_services.dart
+++ b/games_services/lib/src/games_services.dart
@@ -31,8 +31,12 @@ class GamesServices {
 
   /// Get achievements as a list. Use this to build a custom UI.
   /// To show the device's default achievements screen use [showAchievements].
-  static Future<List<AchievementItemData>?> loadAchievements() async {
-    return await Achievements.loadAchievements();
+  ///
+  /// The `forceRefresh` argument will invalidate the cache on Android, fetching
+  /// the latest results. It has no affect on iOS.
+  static Future<List<AchievementItemData>?> loadAchievements(
+      {bool forceRefresh = false}) async {
+    return await Achievements.loadAchievements(forceRefresh: forceRefresh);
   }
 
   /// It will reset the achievements.

--- a/games_services/lib/src/games_services.dart
+++ b/games_services/lib/src/games_services.dart
@@ -175,8 +175,12 @@ class GamesServices {
   }
 
   /// Get all saved games.
-  static Future<List<SavedGame>?> getSavedGames() async {
-    return await SaveGame.getSavedGames();
+  ///
+  /// The `forceRefresh` argument will invalidate the cache on Android, fetching
+  /// the latest results. It has no affect on iOS.
+  static Future<List<SavedGame>?> getSavedGames(
+      {bool forceRefresh = false}) async {
+    return await SaveGame.getSavedGames(forceRefresh: forceRefresh);
   }
 
   /// Delete game with [name].

--- a/games_services/lib/src/games_services.dart
+++ b/games_services/lib/src/games_services.dart
@@ -72,18 +72,25 @@ class GamesServices {
 
   /// Get leaderboard scores as a list. Use this to build a custom UI.
   /// To show the device's default leaderboards screen use [showLeaderboards].
+  ///
+  /// The `forceRefresh` argument will invalidate the cache on Android, fetching
+  /// the latest results. It has no affect on iOS.
   static Future<List<LeaderboardScoreData>?> loadLeaderboardScores(
       {iOSLeaderboardID = "",
       androidLeaderboardID = "",
+      bool playerCentered = false,
       required PlayerScope scope,
       required TimeScope timeScope,
+      bool forceRefresh = false,
       required int maxResults}) async {
     return await Leaderboards.loadLeaderboardScores(
         iOSLeaderboardID: iOSLeaderboardID,
         androidLeaderboardID: androidLeaderboardID,
+        playerCentered: playerCentered,
         scope: scope,
         timeScope: timeScope,
-        maxResults: maxResults);
+        maxResults: maxResults,
+        forceRefresh: forceRefresh);
   }
 
   /// Submit a [score] to specific leaderboard.

--- a/games_services/lib/src/leaderboards.dart
+++ b/games_services/lib/src/leaderboards.dart
@@ -17,12 +17,16 @@ abstract class Leaderboards {
 
   /// Get leaderboard scores as a list. Use this to build a custom UI.
   /// To show the device's default leaderboards screen use [showLeaderboards].
+  ///
+  /// The `forceRefresh` argument will invalidate the cache on Android, fetching
+  /// the latest results. It has no affect on iOS.
   static Future<List<LeaderboardScoreData>?> loadLeaderboardScores(
       {iOSLeaderboardID = "",
       androidLeaderboardID = "",
       bool playerCentered = false,
       required PlayerScope scope,
       required TimeScope timeScope,
+      bool forceRefresh = false,
       required int maxResults}) async {
     final response = await GamesServicesPlatform.instance.loadLeaderboardScores(
         androidLeaderboardID: androidLeaderboardID,
@@ -30,6 +34,7 @@ abstract class Leaderboards {
         playerCentered: playerCentered,
         scope: scope,
         timeScope: timeScope,
+        forceRefresh: forceRefresh,
         maxResults: maxResults);
     if (response != null) {
       Iterable items = json.decode(response) as List;

--- a/games_services/lib/src/save_game.dart
+++ b/games_services/lib/src/save_game.dart
@@ -18,8 +18,13 @@ abstract class SaveGame {
   }
 
   /// Get all saved games.
-  static Future<List<SavedGame>?> getSavedGames() async {
-    final result = await GamesServicesPlatform.instance.getSavedGames();
+  ///
+  /// The `forceRefresh` argument will invalidate the cache on Android, fetching
+  /// the latest results. It has no affect on iOS.
+  static Future<List<SavedGame>?> getSavedGames(
+      {bool forceRefresh = false}) async {
+    final result = await GamesServicesPlatform.instance
+        .getSavedGames(forceRefresh: forceRefresh);
     if (result == null) {
       return null;
     }

--- a/games_services_platform_interface/lib/game_services_platform_interface.dart
+++ b/games_services_platform_interface/lib/game_services_platform_interface.dart
@@ -68,7 +68,7 @@ abstract class GamesServicesPlatform extends PlatformInterface {
 
   /// Get achievements as json data.
   /// To show the device's default achievements screen use [showAchievements].
-  Future<String?> loadAchievements() async {
+  Future<String?> loadAchievements({bool forceRefresh = false}) async {
     throw UnimplementedError("not implemented.");
   }
 

--- a/games_services_platform_interface/lib/game_services_platform_interface.dart
+++ b/games_services_platform_interface/lib/game_services_platform_interface.dart
@@ -182,7 +182,7 @@ abstract class GamesServicesPlatform extends PlatformInterface {
   }
 
   /// Get all saved games.
-  Future<String?> getSavedGames() async {
+  Future<String?> getSavedGames({bool forceRefresh = false}) async {
     throw UnimplementedError("not implemented.");
   }
 }

--- a/games_services_platform_interface/lib/game_services_platform_interface.dart
+++ b/games_services_platform_interface/lib/game_services_platform_interface.dart
@@ -85,7 +85,8 @@ abstract class GamesServicesPlatform extends PlatformInterface {
       bool playerCentered = false,
       required PlayerScope scope,
       required TimeScope timeScope,
-      required int maxResults}) async {
+      required int maxResults,
+      bool forceRefresh = false}) async {
     throw UnimplementedError("not implemented.");
   }
 

--- a/games_services_platform_interface/lib/src/game_services_platform_impl.dart
+++ b/games_services_platform_interface/lib/src/game_services_platform_impl.dart
@@ -70,14 +70,16 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
       bool playerCentered = false,
       required PlayerScope scope,
       required TimeScope timeScope,
-      required int maxResults}) async {
+      required int maxResults,
+      bool forceRefresh = false}) async {
     return await _channel.invokeMethod("loadLeaderboardScores", {
       "leaderboardID":
           Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID,
       "playerCentered": playerCentered,
       "leaderboardCollection": scope.value,
       "span": timeScope.value,
-      "maxResults": maxResults
+      "maxResults": maxResults,
+      "forceRefresh": forceRefresh
     });
   }
 

--- a/games_services_platform_interface/lib/src/game_services_platform_impl.dart
+++ b/games_services_platform_interface/lib/src/game_services_platform_impl.dart
@@ -188,8 +188,9 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
   }
 
   @override
-  Future<String?> getSavedGames() async {
-    return await _channel.invokeMethod("getSavedGames");
+  Future<String?> getSavedGames({bool forceRefresh = false}) async {
+    return await _channel
+        .invokeMethod("getSavedGames", {"forceRefresh": forceRefresh});
   }
 
   @override

--- a/games_services_platform_interface/lib/src/game_services_platform_impl.dart
+++ b/games_services_platform_interface/lib/src/game_services_platform_impl.dart
@@ -54,8 +54,9 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
   }
 
   @override
-  Future<String?> loadAchievements() async {
-    return await _channel.invokeMethod("loadAchievements");
+  Future<String?> loadAchievements({bool forceRefresh = false}) async {
+    return await _channel
+        .invokeMethod("loadAchievements", {"forceRefresh": forceRefresh});
   }
 
   @override


### PR DESCRIPTION
As per the [docs](https://developers.google.com/android/reference/com/google/android/gms/games/LeaderboardsClient#loadTopScores(java.lang.String,%20int,%20int,%20int,%20boolean)), regarding `forceReload`:

> If true, this call will clear any locally cached data and attempt to fetch the latest data from the server. This would commonly be used for something like a user-initiated refresh. Normally, this should be set to false to gain advantages of data caching.

Currently, we provide no `forceReload` option for leaderboards, causing outdated data from the cache to be returned at times. We also always force reload data for both achievements & saved games. As noted in the docs, this should not be the default. Therefore, we should defer to the devs to select the appropriate call for all of these methods.

This has no effect on iOS/MacOS as there is no caching mechanism to invalidate.