### PR TITLE
Add optional `forceRefreshToken` for Android `requestServerSideAccess`.

### DIFF
--- a/games_services/CHANGELOG.md
+++ b/games_services/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.3
+- Add optional Bool forceRefreshToken as parameter for Android GamesSignInClient.requestServerSideAccess, replacing hard-coded false. Defaults to false. by @yukinoshita0219
+
 ## 4.0.2
 - Add getPlayerScoreObject to retrieve rank and other score data for leaderboard and time span. by @egonbeermat
 - Add optional String token to methods that submit and retrieve score. by @egonbeermat

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Auth.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Auth.kt
@@ -42,10 +42,10 @@ class Auth {
     }
   }
 
-  fun getAuthCode(clientID: String, activity: Activity?, result: MethodChannel.Result) {
+  fun getAuthCode(clientID: String, forceRefreshToken: Boolean, activity: Activity?, result: MethodChannel.Result) {
     activity ?: return
     val gamesSignInClient = PlayGames.getGamesSignInClient(activity)
-    gamesSignInClient.requestServerSideAccess(clientID, false).addOnSuccessListener {
+    gamesSignInClient.requestServerSideAccess(clientID, forceRefreshToken).addOnSuccessListener {
       result.success(it)
     }.addOnFailureListener {
       result.error(PluginError.FailedToGetAuthCode.errorCode(), it.message ?: "", null)

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/GamesServicesPlugin.kt
@@ -101,7 +101,8 @@ class GamesServicesPlugin : FlutterPlugin,
       }
       Method.GetAuthCode -> {
         val clientID = call.argument<String>("clientID") ?: ""
-        auth.getAuthCode(clientID, activity, result)
+        val forceRefreshToken = call.argument<Boolean>("forceRefreshToken") ?: false
+        auth.getAuthCode(clientID, forceRefreshToken, activity, result)
       }
       Method.ShowAchievements -> {
         achievements?.showAchievements(activity, result)

--- a/games_services/lib/src/game_auth.dart
+++ b/games_services/lib/src/game_auth.dart
@@ -13,6 +13,6 @@ abstract class GameAuth {
 
   /// Retrieve a Google Play Games `server_auth_code` to be used by a backend,
   /// such as Firebase, to authenticate the user. `null` on other platforms.
-  static Future<String?> getAuthCode(String clientID) async =>
-      await GamesServicesPlatform.instance.getAuthCode(clientID);
+  static Future<String?> getAuthCode(String clientID, {bool forceRefreshToken = false}) =>
+      GamesServicesPlatform.instance.getAuthCode(clientID, forceRefreshToken: forceRefreshToken);
 }

--- a/games_services_platform_interface/lib/game_services_platform_interface.dart
+++ b/games_services_platform_interface/lib/game_services_platform_interface.dart
@@ -61,8 +61,7 @@ abstract class GamesServicesPlatform extends PlatformInterface {
 
   /// Open the device's default leaderboards screen. If a leaderboard ID is provided,
   /// it will display the specific leaderboard, otherwise it will show the list of all leaderboards.
-  Future<String?> showLeaderboards(
-      {iOSLeaderboardID = "", androidLeaderboardID = ""}) async {
+  Future<String?> showLeaderboards({iOSLeaderboardID = "", androidLeaderboardID = ""}) async {
     throw UnimplementedError("not implemented.");
   }
 
@@ -100,14 +99,12 @@ abstract class GamesServicesPlatform extends PlatformInterface {
   }
 
   /// Get the current player's score for a specific leaderboard.
-  Future<int?> getPlayerScore(
-      {iOSLeaderboardID = "", androidLeaderboardID = ""}) async {
+  Future<int?> getPlayerScore({iOSLeaderboardID = "", androidLeaderboardID = ""}) async {
     throw UnimplementedError("not implemented.");
   }
 
   /// Check if the current player is underage (always false on Android).
-  Future<bool?> get playerIsUnderage =>
-      throw UnimplementedError("not implemented.");
+  Future<bool?> get playerIsUnderage => throw UnimplementedError("not implemented.");
 
   /// Check if the current player is restricted from joining multiplayer games (always false on Android).
   Future<bool?> get playerIsMultiplayerGamingRestricted =>
@@ -129,7 +126,7 @@ abstract class GamesServicesPlatform extends PlatformInterface {
 
   /// Retrieve Google Play Games [server_auth_code] to be used by an auth provider,
   /// such as Firebase, to authenticate the user. [null] on other platforms.
-  Future<String?> getAuthCode(String clientID) =>
+  Future<String?> getAuthCode(String clientID, {bool forceRefreshToken = false}) =>
       throw UnimplementedError("not implemented.");
 
   /// Show the Game Center Access Point for the current player.

--- a/games_services_platform_interface/lib/src/game_services_platform_impl.dart
+++ b/games_services_platform_interface/lib/src/game_services_platform_impl.dart
@@ -24,11 +24,8 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
 
   @override
   Future<String?> submitScore({required Score score}) async {
-    return await _channel.invokeMethod("submitScore", {
-      "leaderboardID": score.leaderboardID,
-      "value": score.value,
-      "token": score.token
-    });
+    return await _channel.invokeMethod("submitScore",
+        {"leaderboardID": score.leaderboardID, "value": score.value, "token": score.token});
   }
 
   @override
@@ -45,12 +42,9 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
   }
 
   @override
-  Future<String?> showLeaderboards(
-      {iOSLeaderboardID = "", androidLeaderboardID = ""}) async {
-    return await _channel.invokeMethod("showLeaderboards", {
-      "leaderboardID":
-          Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID
-    });
+  Future<String?> showLeaderboards({iOSLeaderboardID = "", androidLeaderboardID = ""}) async {
+    return await _channel.invokeMethod("showLeaderboards",
+        {"leaderboardID": Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID});
   }
 
   @override
@@ -72,8 +66,7 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
       required TimeScope timeScope,
       required int maxResults}) async {
     return await _channel.invokeMethod("loadLeaderboardScores", {
-      "leaderboardID":
-          Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID,
+      "leaderboardID": Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID,
       "playerCentered": playerCentered,
       "leaderboardCollection": scope.value,
       "span": timeScope.value,
@@ -82,12 +75,9 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
   }
 
   @override
-  Future<int?> getPlayerScore(
-      {iOSLeaderboardID = "", androidLeaderboardID = ""}) async {
-    return await _channel.invokeMethod("getPlayerScore", {
-      "leaderboardID":
-          Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID
-    });
+  Future<int?> getPlayerScore({iOSLeaderboardID = "", androidLeaderboardID = ""}) async {
+    return await _channel.invokeMethod("getPlayerScore",
+        {"leaderboardID": Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID});
   }
 
   @override
@@ -97,8 +87,7 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
       required PlayerScope scope,
       required TimeScope timeScope}) async {
     return await _channel.invokeMethod("getPlayerScoreObject", {
-      "leaderboardID":
-          Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID,
+      "leaderboardID": Device.isPlatformAndroid ? androidLeaderboardID : iOSLeaderboardID,
       "leaderboardCollection": scope.value,
       "span": timeScope.value
     });
@@ -113,9 +102,11 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
   Future<bool?> get isSignedIn => _channel.invokeMethod("isSignedIn");
 
   @override
-  Future<String?> getAuthCode(String clientID) => Device.isPlatformAndroid
-      ? _channel.invokeMethod("getAuthCode", {"clientID": clientID})
-      : Future.value(null);
+  Future<String?> getAuthCode(String clientID, {bool forceRefreshToken = false}) =>
+      Device.isPlatformAndroid
+          ? _channel.invokeMethod(
+              "getAuthCode", {"clientID": clientID, "forceRefreshToken": forceRefreshToken})
+          : Future.value(null);
 
   @override
   Future<bool?> get playerIsUnderage async {
@@ -138,14 +129,13 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
     if (Device.isPlatformAndroid) {
       return Future.value(false);
     }
-    return await _channel
-        .invokeMethod("playerIsPersonalizedCommunicationRestricted");
+    return await _channel.invokeMethod("playerIsPersonalizedCommunicationRestricted");
   }
 
   @override
   Future<String?> showAccessPoint(AccessPointLocation location) async {
-    return await _channel.invokeMethod(
-        "showAccessPoint", {"location": location.toString().split(".").last});
+    return await _channel
+        .invokeMethod("showAccessPoint", {"location": location.toString().split(".").last});
   }
 
   @override
@@ -175,8 +165,7 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
 
   @override
   Future<String?> saveGame({required String data, required String name}) async {
-    return await _channel
-        .invokeMethod("saveGame", {"data": data, "name": name});
+    return await _channel.invokeMethod("saveGame", {"data": data, "name": name});
   }
 
   @override


### PR DESCRIPTION
As per the [docs](https://developer.android.com/games/pgs/android/server-access#get_the_server_auth_code), Android `GamesSignInClient.requestServerSideAccess` has an optional parameter `forceRefreshToken`.
> (Optional) If your game server requires offline access (long lived access using a refresh token) to Play Games Services, you can set the forceRefreshToken parameter to true.

However it is hard-coded to be `false`. I changed it to an optional parameter which defaults to `false`.