### PR TITLE
Log message adjusted

### DIFF
--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/SaveGame.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/SaveGame.kt
@@ -75,7 +75,7 @@ class SaveGame(private var activityPluginBinding: ActivityPluginBinding) {
           // Commit the operation
           snapshotsClient.commitAndClose(snapshot, metadataChange)
             .addOnSuccessListener {
-              Log.d(tag, "[SaveGame] Loaded successfully")
+              Log.d(tag, "[SaveGame] Saved successfully")
               result.success(null)
             }
             .addOnFailureListener {


### PR DESCRIPTION
I discovered the following lines in the log and found them a bit confusing:

```
[SaveGame] Start saving game
[SaveGame] Start commit
[SaveGame] Loaded successfully
```
This PR should fix it, the new output will be:
```
[SaveGame] Start saving game
[SaveGame] Start commit
[SaveGame] Saved successfully
```
