### PR TITLE
Fix cancelled subs bug.

### DIFF
--- a/games_services/darwin/games_services.podspec
+++ b/games_services/darwin/games_services.podspec
@@ -3,14 +3,14 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'games_services'
-  s.version          = '0.0.1'
-  s.summary          = 'A new Flutter plugin to support game center and google play games services.'
+  s.version          = '4.1.0'
+  s.summary          = 'A Flutter plugin to support Game Center and Google Play Games services.'
   s.description      = <<-DESC
-A new Flutter plugin to support game center and google play games services.
+A Flutter plugin to support Game Center and Google Play Games services.
                        DESC
-  s.homepage         = 'http://example.com'
+  s.homepage         = 'https://github.com/Abedalkareem/games_services'
   s.license          = { :file => '../LICENSE' }
-  s.author           = { 'Your Company' => 'email@example.com' }
+  s.author           = { '' => 'abedalkareem.omreyh@yahoo.com' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
@@ -18,7 +18,7 @@ A new Flutter plugin to support game center and google play games services.
 
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.4'
   s.osx.deployment_target = '11.0'
 end
 

--- a/games_services/example/ios/Podfile
+++ b/games_services/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '12.0'
+platform :ios, '12.4'
 use_frameworks! 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/games_services/lib/src/game_auth.dart
+++ b/games_services/lib/src/game_auth.dart
@@ -7,7 +7,7 @@ abstract class GameAuth {
   /// Stream of the currently authenticated player. If not null, the player
   /// is signed in & games_services functionality is available.
   static Stream<PlayerData?> get player =>
-      GamesServicesPlatform.instance.player;
+      GamesServicesPlatform.instance.player.distinct();
 
   /// Sign the user into Game Center or Google Play Games. This must be called before
   /// taking any action (such as submitting a score or unlocking an achievement).

--- a/games_services/lib/src/game_auth.dart
+++ b/games_services/lib/src/game_auth.dart
@@ -18,7 +18,7 @@ abstract class GameAuth {
     // resuses player stream to reduce code and platform channel communciation
     final completer = Completer<bool>();
     StreamSubscription? sub;
-    sub = GamesServicesPlatform.instance.player.listen((data) {
+    sub = player.listen((data) {
       completer.complete(data != null);
       sub?.cancel();
     }, onError: (_) {

--- a/games_services_platform_interface/lib/src/game_services_platform_impl.dart
+++ b/games_services_platform_interface/lib/src/game_services_platform_impl.dart
@@ -29,7 +29,10 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
             .listen((player) {
           _player = player;
           _streamController.add(_player);
-        }, onError: (error) => _streamController.add(null));
+        }, onError: (error) {
+          _player = null;
+          _streamController.add(null);
+        });
       },
       onCancel: () {
         // cancel sub to platform event channel when last listener removed

--- a/games_services_platform_interface/lib/src/game_services_platform_impl.dart
+++ b/games_services_platform_interface/lib/src/game_services_platform_impl.dart
@@ -35,6 +35,7 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
         // cancel sub to platform event channel when last listener removed
         // new listeners added after this will recreate the subscription
         _sub?.cancel();
+        _sub = null;
       },
     );
   }


### PR DESCRIPTION
This PR completes the implementation of the player stream. The following changes are included.

1) [BUG FIX] Set the MethodChannel subscription to `null` when all listeners are cancelled. Previously just cancelled the sub, which would not allow new subs, as there is a null check before assigning a new sub. Fixes #158.

2) [BUG FIX] Set the cached player to `null` when an error occurs across the `player` stream.

3) [QoL] Make the `player` stream `distinct`, meaning that current listeners do not receive duplicate data when new listeners are added or legacy methods are called.

4) [QoL] Bump iOS deployment target to 12.4 which provides better feedback to the dev when building for iOS, as it is now necessary due to the use of `gamePlayerID` (`playerID` is deprecated). It will also be necessary when upgrading from other deprecated GameKit methods.

5) [QoL] Update some information in the podspec file to match the version number and provide links to the GitHub.