### PR TITLE
Fixes delay in some results after sign in

### DIFF
--- a/games_services/pubspec.yaml
+++ b/games_services/pubspec.yaml
@@ -1,6 +1,6 @@
 name: games_services
 description: A new Flutter plugin to support game center and google play games services.
-version: 4.1.0
+version: 4.1.1
 homepage: https://github.com/Abedalkareem/games_services
 repository: https://github.com/Abedalkareem/games_services
 issue_tracker: https://github.com/Abedalkareem/games_services/issues
@@ -13,8 +13,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  games_services_platform_interface: ^4.1.0
-    # path: ../games_services_platform_interface/
+  games_services_platform_interface: # ^4.1.1
+    path: ../games_services_platform_interface/
     #uncomment in time of development.
     # git:
     #   url: https://github.com/Abedalkareem/games_services

--- a/games_services_platform_interface/lib/src/game_services_platform_impl.dart
+++ b/games_services_platform_interface/lib/src/game_services_platform_impl.dart
@@ -52,10 +52,13 @@ class MethodChannelGamesServices extends GamesServicesPlatform {
 
   @override
   Stream<PlayerData?> get player {
-    // to maintain backwards compatibility, add latest player when
-    // listened to by plugin methods. also guarantees synced player data
+    // In order to maintain backwards compatibility, if the channel stream is
+    // already subscribed to, add the latest player data listeners from legacy
+    // plugin methods. This also guarantees synced player data
     // while listening for the user in multiple places throughout the app
-    Future(() => _streamController.add(_player));
+    if (_sub != null) {
+      Future(() => _streamController.add(_player));
+    }
     return _streamController.stream;
   }
 

--- a/games_services_platform_interface/pubspec.yaml
+++ b/games_services_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: games_services_platform_interface
 description: A common platform interface for the games_services plugin.
 homepage: https://github.com/Abedalkareem/games_services
-version: 4.1.0
+version: 4.1.1
 
 environment:
   sdk: '>=2.12.0 <4.0.0'


### PR DESCRIPTION
Certain legacy implementations may see a delay in sign-in status and functionality directly after successful sign-in. This update resolves that issue by only using the "cached" `player` value if a stream is currently open. Otherwise, it only uses the new value transmitted when a new channel stream is created.

Fixes #188 