### PR TITLE
Add check for persistent IDs from GameCenter.

### DIFF
--- a/games_services/CHANGELOG.md
+++ b/games_services/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.1
+
+- Return `null` for `playerID` and `teamPlayerID` when GameCenter configuration errors lead to temporary IDs. by @theLee3
+
 ## 5.0.0
 
 - Return success instead of null in case of success.

--- a/games_services/darwin/Classes/Auth.swift
+++ b/games_services/darwin/Classes/Auth.swift
@@ -130,10 +130,11 @@ class Auth: BaseGamesServices {
   // MARK: - Private Methods
   
   private func triggerNewPlayerEvent(shouldUpdateResults: Bool = false) {
+    let isPersistent = self.currentPlayer.scopedIDsArePersistent()
     var player = PlayerData(
       displayName: self.currentPlayer.alias,
-      playerID: self.currentPlayer.gamePlayerID,
-      teamPlayerID: self.currentPlayer.teamPlayerID,
+      playerID: isPersistent ? self.currentPlayer.gamePlayerID : nil,
+      teamPlayerID: isPersistent ? self.currentPlayer.teamPlayerID : nil,
       isUnderage: self.currentPlayer.isUnderage
     )
     if #available(iOS 13.0, *) {

--- a/games_services/darwin/Classes/Models/PlayerData.swift
+++ b/games_services/darwin/Classes/Models/PlayerData.swift
@@ -1,7 +1,7 @@
 struct PlayerData: Codable {
   var displayName: String
-  var playerID: String
-  var teamPlayerID: String
+  var playerID: String?
+  var teamPlayerID: String?
   var iconImage: String?
   var isUnderage: Bool?
   var isMultiplayerGamingRestricted: Bool?

--- a/games_services/pubspec.yaml
+++ b/games_services/pubspec.yaml
@@ -1,6 +1,6 @@
 name: games_services
 description: A new Flutter plugin to support game center and google play games services.
-version: 5.0.0
+version: 5.0.1
 homepage: https://github.com/Abedalkareem/games_services
 repository: https://github.com/Abedalkareem/games_services
 issue_tracker: https://github.com/Abedalkareem/games_services/issues
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  games_services_platform_interface: ^5.0.0
+  games_services_platform_interface: ^5.0.1
     # path: ../games_services_platform_interface/
     #uncomment in time of development.
     # git:

--- a/games_services_platform_interface/CHANGELOG.md
+++ b/games_services_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.1
+
+- Return `null` for `playerID` and `teamPlayerID` when GameCenter configuration errors lead to temporary IDs. by @theLee3
+
 ## 5.0.0
 
 - Return success instead of null in case of success.
@@ -19,9 +23,11 @@
 - Handle Play Services missing/outdated issues by returning error from `signIn` and presenting native dialog allowing user to resolve the issue. by @theLee3
 
 ## 4.0.3
+
 - Add optional Bool forceRefreshToken as parameter for Android GamesSignInClient.requestServerSideAccess, replacing hard-coded false. Defaults to false. by @yukinoshita0219
 
 ## 4.0.2
+
 - Add getPlayerScoreObject to retrieve rank and other score data for leaderboard and time span. by @egonbeermat
 - Add optional String token to methods that submit and retrieve score. by @egonbeermat
 - Add optional Bool showsCompletionBanner as parameter for iOS GKAchievement.report, replacing hard-coded true. Defaults to true. by @egonbeermat
@@ -30,6 +36,7 @@
 - Add logs to save game.
 
 ## 4.0.1
+
 - Add ability to get Play Games auth code for use with backends by @theLee3
 - Add PlayerData class to return more score holder details by @theLee3
 - Add isAuthenticated check alongside DEBUG signInFailed by @theLee3
@@ -38,59 +45,77 @@
 - Ensure all task exceptions are handled, to prevent crashes. by @Erfa
 
 ## 4.0.0
+
 - migrate to google play games services 2.0.0.
 - use darwin folder for iOS and macOS.
 
 ## 3.0.3
+
 - add getPlayer by @theLee3
 
 ## 3.0.1
+
 - add playerIsUnderage
 - add playerIsMultiplayerGamingRestricted
 - add playerIsPersonalizedCommunicationRestricted
 
 ## 3.0.0
+
 - Rearrange classes to group features. `GameAuth` for authintication, `Achievements` for anything related to Achievements, `Leaderboards` for anything related to Leaderboards, `Player` for anything related to Player, and `SaveGame` for anything related to save game.
 
 ## 2.2.2
+
 - Add load achievements.
 - Add load leaderboard scores.
 
 ## 2.2.1
+
 - Add shouldEnableSavedGame to sign in.
 
 ## 2.2.0
+
 - Add save and load game 🎁 👾.
 
 ## 2.0.9
+
 - Support getting the current player score.
 
 ## 2.0.6
+
 - Support getting the player name.
 
 ## 2.0.5
+
 - Support getting the player id.
 
 ## 2.0.1
+
 - Fix the leaderboard id.
 
 ## 2.0.0
+
 - 💪 Running with sound null safety 💪.
 
 ## 1.0.9
+
 - Add the iOS Access point.
 
 ## 1.0.7
+
 - Add increment method by @tommybuonomo.
 
 ## 1.0.5
+
 - Change the method channel.
 
 ## 1.0.2
+
 - Remove the static keyword for showAchievements, showLeaderboards and signIn.
 
 ## 1.0.1
+
 - Remove the static keyword.
 
 ## 1.0.0
+
 - Initial open-source release.

--- a/games_services_platform_interface/lib/src/models/player.dart
+++ b/games_services_platform_interface/lib/src/models/player.dart
@@ -1,13 +1,17 @@
 class PlayerData {
-  /// Value can be `null` on Android due to privacy settings
+  /// Value can be `null` on Android due to privacy settings or in the case of a
+  /// GameCenter configuration issue, as GameCenter will provide a temporary ID
+  /// which will not persist between game sessions.
   final String? playerID;
   final String displayName;
   final String? iconImage;
 
-  /// only available from GameCenter
+  /// Only available from GameCenter.
+  /// May be null if there is GameCenter configuration issue, as GameCenter will
+  /// provide a temporary ID which will not persist between game sessions.
   final String? teamPlayerID;
 
-  /// only available from GameCenter
+  /// Only available from GameCenter.
   final bool? isUnderage,
       isMultiplayerGamingRestricted,
       isPersonalizedCommunicationRestricted;

--- a/games_services_platform_interface/pubspec.yaml
+++ b/games_services_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: games_services_platform_interface
 description: A common platform interface for the games_services plugin.
 homepage: https://github.com/Abedalkareem/games_services
-version: 5.0.0
+version: 5.0.1
 
 environment:
   sdk: '>=2.12.0 <4.0.0'


### PR DESCRIPTION
Adds a check for persistent IDs from GameCenter via `scopedIDsArePersistent`. IDs can be temporary if GameCenter is misconfigured. If IDs are temporary, we return `null` to avoid confusion.