### PR TITLE
Fix a NullPointerException that could occur during sign in on Android

### DIFF
--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Auth.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Auth.kt
@@ -64,6 +64,15 @@ class Auth(private var activityPluginBinding: ActivityPluginBinding) :
       it?.let { result ->
         if (result.isAuthenticated) {
           playersClient.currentPlayer.addOnSuccessListener { player ->
+            // player can be null due to project configuration issues
+            if (player == null) {
+              finishPendingOperationWithError(
+                PluginError.FailedToAuthenticate.errorCode(),
+                "Player is null. Please ensure that your project is configured correctly."
+              )
+              return@addOnSuccessListener
+            }
+
             var playerData = PlayerData(
               player.displayName,
               player.playerId,

--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/models/PlayerData.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/models/PlayerData.kt
@@ -3,7 +3,7 @@ package com.abedalkareem.games_services.models
 data class PlayerData(
   val displayName: String,
   // playerID may be null if privacy settings do not allow current player
-  // to see info about the this player
+  // to see info about the player
   val playerID: String?,
   val iconImage: String?
 )


### PR DESCRIPTION
This could occur if the sign in is successful but the project is misconfigured, causing the `player` value to be `null`. This will now return an error with suggestion to check the project configuration.

Closes #219 