### PR TITLE
Migrate to AGP 9 and built-in Kotlin.

### DIFF
--- a/games_services/android/build.gradle
+++ b/games_services/android/build.gradle
@@ -1,16 +1,14 @@
-group 'com.abedalkareem.games_services'
-version '1.0-SNAPSHOT'
+group = 'com.abedalkareem.games_services'
+version = '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.2.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.13.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.android.tools.build:gradle:9.0.1'
         classpath 'com.google.gms:google-services:4.4.4'
     }
 }
@@ -23,17 +21,16 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
-    namespace 'com.abedalkareem.games_services'
+    namespace = 'com.abedalkareem.games_services'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
 
     defaultConfig {
-        compileSdkVersion 34
+        compileSdkVersion 36
         minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "proguard-rules.pro"
@@ -44,17 +41,18 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
+}
 
-    kotlinOptions {
-        jvmTarget = '17'
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'com.google.code.gson:gson:2.13.2'
+    implementation 'com.google.code.gson:gson:2.14.0'
     implementation "com.google.android.gms:play-services-games-v2:21.0.0"
 }

--- a/games_services/android/gradle/wrapper/gradle-wrapper.properties
+++ b/games_services/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Aug 11 13:19:46 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/games_services/lib/src/leaderboards.dart
+++ b/games_services/lib/src/leaderboards.dart
@@ -8,8 +8,8 @@ abstract class Leaderboards {
   /// Open the device's default leaderboards screen. If a leaderboard ID is provided,
   /// it will display the specific leaderboard, otherwise it will show the list of all leaderboards.
   static Future<String?> showLeaderboards({
-    String? iOSLeaderboardID = "",
-    String? androidLeaderboardID = "",
+    String iOSLeaderboardID = "",
+    String androidLeaderboardID = "",
   }) async {
     return await GamesServicesPlatform.instance.showLeaderboards(
       iOSLeaderboardID: iOSLeaderboardID,
@@ -23,8 +23,8 @@ abstract class Leaderboards {
   /// The `forceRefresh` argument will invalidate the cache on Android, fetching
   /// the latest results. It has no affect on iOS.
   static Future<List<LeaderboardScoreData>?> loadLeaderboardScores({
-    String? iOSLeaderboardID = "",
-    String? androidLeaderboardID = "",
+    String iOSLeaderboardID = "",
+    String androidLeaderboardID = "",
     bool playerCentered = false,
     required PlayerScope scope,
     required TimeScope timeScope,
@@ -50,8 +50,8 @@ abstract class Leaderboards {
 
   /// Get leaderboard score data for the current player
   static Future<LeaderboardScoreData?> getPlayerScoreObject({
-    String? iOSLeaderboardID = "",
-    String? androidLeaderboardID = "",
+    String iOSLeaderboardID = "",
+    String androidLeaderboardID = "",
     required PlayerScope scope,
     required TimeScope timeScope,
   }) async {
@@ -72,8 +72,8 @@ abstract class Leaderboards {
   /// This is useful for tracking score progression over time.
   /// Currently only supported on iOS 14.0+ and macOS 11.0+.
   static Future<LeaderboardScoreData?> loadPreviousOccurrence({
-    String? iOSLeaderboardID = "",
-    String? androidLeaderboardID = "",
+    String iOSLeaderboardID = "",
+    String androidLeaderboardID = "",
     required TimeScope timeScope,
   }) async {
     final String? response =

--- a/games_services/lib/src/player.dart
+++ b/games_services/lib/src/player.dart
@@ -71,8 +71,8 @@ abstract class Player {
 
   /// Get the current player's score for a specific leaderboard.
   static Future<int?> getPlayerScore({
-    String? iOSLeaderboardID = "",
-    String? androidLeaderboardID = "",
+    String iOSLeaderboardID = "",
+    String androidLeaderboardID = "",
   }) async {
     return await GamesServicesPlatform.instance.getPlayerScore(
       iOSLeaderboardID: iOSLeaderboardID,

--- a/games_services/pubspec.yaml
+++ b/games_services/pubspec.yaml
@@ -6,15 +6,15 @@ repository: https://github.com/Abedalkareem/games_services
 issue_tracker: https://github.com/Abedalkareem/games_services/issues
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
-  flutter: ">=1.22.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:
     sdk: flutter
 
-  games_services_platform_interface: ^5.0.1
-    # path: ../games_services_platform_interface/
+  games_services_platform_interface: #^5.0.1
+    path: ../games_services_platform_interface/
     #uncomment in time of development.
     # git:
     #   url: https://github.com/Abedalkareem/games_services


### PR DESCRIPTION
This PR updates the Android plugin to AGP 9 using the built-in Kotlin. Closing #226. This will future proof the plugin, before the transition becomes mandatory.

This does bump the minimum Flutter version to 3.44. I attempted to follow the instructions [here](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors#supporting-flutter-versions-earlier-than-3-44) to support earlier versions as well, but had no success.

@Abedalkareem, if you feel that we need to maintain support for older versions of Flutter for some reason, I encourage you to take a look at the link and see if you have better success.