### PR TITLE
 iOS/macOS: distinct `sign_in_unavailable` error code when the sign-in UI won't present

### DIFF
--- a/games_services/darwin/games_services/Sources/games_services/Auth.swift
+++ b/games_services/darwin/games_services/Sources/games_services/Auth.swift
@@ -33,8 +33,15 @@ class Auth: BaseGamesServices {
       if (isAuthenticated || self.result != nil) {
         result(Messages.alreadyAuthenticated)
       } else {
-        eventSink?(PluginError.failedToAuthenticate.flutterError())
-        result(PluginError.failedToAuthenticate.flutterError())
+        // The handler is already set and the player is still not authenticated,
+        // with no attempt in flight. GameKit will not present the sign-in UI again
+        // from the app while in this state. The usual reason is that Game Center is
+        // turned off or restricted in the device's Settings, or no account is signed
+        // in there — i.e. something the user can only resolve in Settings, not by
+        // retrying in-app. Surface a distinct error so callers can route the user to
+        // the device's Game Center settings instead of silently retrying.
+        eventSink?(PluginError.signInUnavailable.flutterError())
+        result(PluginError.signInUnavailable.flutterError())
       }
       return
     }

--- a/games_services/darwin/games_services/Sources/games_services/Util/Error.swift
+++ b/games_services/darwin/games_services/Sources/games_services/Util/Error.swift
@@ -25,6 +25,8 @@ enum PluginError: String {
       return "Failed to send the achievement"
     case .failedToAuthenticate:
       return "Failed to authenticate"
+    case .signInUnavailable:
+      return "Sign-in is unavailable. Game Center will not present the sign-in UI from the app, typically because it is turned off or restricted in the device's Settings, or no account is signed in. The user must sign in from the device's Game Center settings."
     case .failedToGetPlayerProfileImage:
       return "Failed to get player profile image"
     case .notSupportedForThisOSVersion:
@@ -56,6 +58,7 @@ enum PluginError: String {
   case failedToGetScore = "failed_to_get_score"
   case failedToSendAchievement = "failed_to_send_achievement"
   case failedToAuthenticate = "failed_to_authenticate"
+  case signInUnavailable = "sign_in_unavailable"
   case failedToGetPlayerProfileImage = "failed_to_get_player_profile_image"
   case failedToSaveGame = "failed_to_save_game"
   case failedToLoadGame = "failed_to_load_game"


### PR DESCRIPTION
Added a separate error code for iOS when the sign-in UI won't present, so that client apps can distinguish between "The user saw the modal and closed it without signing in" and "The modal didn't show".

As an example for what that's useful: In my app I have a button for the user to sign into Game Center / Google Play. The Game Center modal won't show when it's been closed once already or when Game Center is switched off in the settings. In that case, I show a dialog directing the user to navigate to the settings and activating Game Center there.

For Android it's not necessary, because from my tests, the sign in UI would show every time, no matter how many times it's been declined already.