### PR TITLE
Migrate to `GkAccessPoint.trigger` for system UI calls where appropriate

### DIFF
--- a/games_services/darwin/games_services/Sources/games_services/Achievements.swift
+++ b/games_services/darwin/games_services/Sources/games_services/Achievements.swift
@@ -8,9 +8,13 @@ import FlutterMacOS
 class Achievements: BaseGamesServices {
   
   func showAchievements(result: @escaping FlutterResult) {
-    let viewController = GKGameCenterViewController(state: .achievements)
-    viewController.gameCenterDelegate = self
-    self.viewController?.show(viewController)
+    if #available(iOS 18.0, macOS 15.0, *) {
+      GKAccessPoint.shared.trigger(state: .achievements, handler: {})
+    } else {
+      let viewController = GKGameCenterViewController(state: .achievements)
+      viewController.gameCenterDelegate = self
+      self.viewController?.show(viewController)
+    }
     result(Messages.success)
   }
   

--- a/games_services/darwin/games_services/Sources/games_services/Leaderboards.swift
+++ b/games_services/darwin/games_services/Sources/games_services/Leaderboards.swift
@@ -8,13 +8,28 @@ import FlutterMacOS
 class Leaderboards: BaseGamesServices {
   
   func showLeaderboardWith(identifier: String, span: Int, leaderboardCollection: Int, result: @escaping FlutterResult) {
-    let viewController = GKGameCenterViewController(
-      leaderboardID: identifier,
-      playerScope: GKLeaderboard.PlayerScope(rawValue: leaderboardCollection) ?? .global,
-      timeScope: GKLeaderboard.TimeScope(rawValue: span) ?? .allTime
-    )
-    viewController.gameCenterDelegate = self
-    self.viewController?.show(viewController)
+    let playerScope = GKLeaderboard.PlayerScope(rawValue: leaderboardCollection) ?? .global
+    let timeScope = GKLeaderboard.TimeScope(rawValue: span) ?? .allTime
+    if #available(iOS 18.0, macOS 15.0, *) {
+      if (identifier.isEmpty) {
+        GKAccessPoint.shared.trigger(state: .leaderboards, handler: {})
+      } else {
+        GKAccessPoint.shared.trigger(
+          leaderboardID: identifier,
+          playerScope: playerScope,
+          timeScope: timeScope,
+          handler: {}
+        )
+      }
+    } else {
+      let viewController = GKGameCenterViewController(
+        leaderboardID: identifier,
+        playerScope: playerScope,
+        timeScope: timeScope
+      )
+      viewController.gameCenterDelegate = self
+      self.viewController?.show(viewController)
+    }
     result(Messages.success)
   }
   


### PR DESCRIPTION
`GKGameCenterViewController` is no longer functional on iOS/MacOS versions higher than 26.0.

This PR updates `Achievements.showAchievements` & `Leaderboards.showLeaderboards` to use `GkAccessPoint.trigger` instead on supported iOS/macOS versions.

Closes #241 