### PR TITLE
chore(release): 5.2.0

### DIFF
--- a/games_services/CHANGELOG.md
+++ b/games_services/CHANGELOG.md
@@ -1,7 +1,9 @@
-## Unreleased
+## 5.2.0
 
-- Add Android support for setting an incremental achievement's absolute step progress.
-- Fix legacy Auth/Player methods returning stale data.
+- Add Android support for setting an incremental achievement's absolute step progress via `Achievements.setSteps`. (#245)
+- Add a distinct `sign_in_unavailable` error code on iOS/macOS when the sign-in UI won't present. (#237)
+- Migrate `showAchievements` and `showLeaderboards` to `GKAccessPoint.trigger` on supported iOS/macOS versions (fixes the non-functional `GKGameCenterViewController` on iOS/macOS 26+). (#243)
+- Fix legacy Auth/Player methods returning stale cached `PlayerData`. (#242)
 
 ## 5.1.0
 

--- a/games_services/pubspec.yaml
+++ b/games_services/pubspec.yaml
@@ -1,6 +1,6 @@
 name: games_services
 description: A new Flutter plugin to support game center and google play games services.
-version: 5.1.0
+version: 5.2.0
 homepage: https://github.com/Abedalkareem/games_services
 repository: https://github.com/Abedalkareem/games_services
 issue_tracker: https://github.com/Abedalkareem/games_services/issues
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  games_services_platform_interface: #^5.1.1
+  games_services_platform_interface: #^5.2.0
     path: ../games_services_platform_interface/
     #uncomment in time of development.
     # git:

--- a/games_services_platform_interface/CHANGELOG.md
+++ b/games_services_platform_interface/CHANGELOG.md
@@ -1,7 +1,7 @@
-## Unreleased
+## 5.2.0
 
-- Add the Android-only `setSteps` achievement operation.
-- Fix legacy Auth/Player methods returning stale data.
+- Add the Android-only `setSteps` achievement operation. (#245)
+- Fix legacy Auth/Player methods returning stale cached `PlayerData`. (#242)
 
 ## 5.1.0
 

--- a/games_services_platform_interface/pubspec.yaml
+++ b/games_services_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: games_services_platform_interface
 description: A common platform interface for the games_services plugin.
 homepage: https://github.com/Abedalkareem/games_services
-version: 5.1.0
+version: 5.2.0
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
Release **games_services** and **games_services_platform_interface** at **5.2.0** (minor bump — adds a new public API).

Bundles the four PRs merged into develop since 5.1.0:
- #245 — Android \`Achievements.setSteps\` (new feature → minor bump)
- #237 — iOS/macOS distinct \`sign_in_unavailable\` error code
- #243 — Migrate \`showAchievements\`/\`showLeaderboards\` to \`GKAccessPoint.trigger\` on iOS/macOS 26+
- #242 — Fix stale cached \`PlayerData\`

Changes:
- Bump both packages 5.1.0 → 5.2.0
- Finalize both CHANGELOGs under \`## 5.2.0\`

After merge: tag \`5.2.0\`, GitHub release, publish both packages to pub.dev (interface first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)