### PR TITLE
fix(android): null-guard Player in Auth.onListen and getPlayerProfileImage

### DIFF
--- a/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Auth.kt
+++ b/games_services/android/src/main/kotlin/com/abedalkareem/games_services/Auth.kt
@@ -118,6 +118,10 @@ class Auth(private var activityPluginBinding: ActivityPluginBinding) :
 
   fun getPlayerProfileImage(result: MethodChannel.Result) {
     playersClient.currentPlayer.addOnSuccessListener { player ->
+      if (player == null) {
+        result.error(PluginError.FailedToGetPlayerProfileImage.errorCode(), "Player is null", null)
+        return@addOnSuccessListener
+      }
       val handler = CoroutineExceptionHandler { _, exception ->
         result.error(
           PluginError.FailedToGetPlayerProfileImage.errorCode(),
@@ -143,6 +147,11 @@ class Auth(private var activityPluginBinding: ActivityPluginBinding) :
               isAuthenticatedTask.result.isAuthenticated
       if (isAuthenticated) {
         playersClient.currentPlayer.addOnSuccessListener { player ->
+          // player can be null due to project configuration issues
+          if (player == null) {
+            events?.error(PluginError.FailedToAuthenticate.errorCode(), "Player is null. Please ensure that your project is configured correctly.", null)
+            return@addOnSuccessListener
+          }
           var playerData = PlayerData(
             player.displayName,
             player.playerId,


### PR DESCRIPTION
## Problem

`PlayersClient.currentPlayer` can complete **successfully with a null `Player`** (seen in production on a Xiaomi Mi 10 Pro, games_services 5.0.0 and reproducible against current `develop`). `Auth.onListen` — which backs `GameAuth.player` and therefore `GameAuth.isSignedIn` / `GamesServices.isSignedIn` — dereferences it immediately:

```
Fatal Exception: java.lang.NullPointerException
Attempt to invoke interface method 'java.lang.String com.google.android.gms.games.Player.getDisplayName()' on a null object reference
  at com.abedalkareem.games_services.Auth.onListen$lambda$0$0 (Auth.kt:147)
  at com.abedalkareem.games_services.Auth.onListen$lambda$0$1 (Auth.kt:145)
  at com.google.android.gms.tasks.zzm.run
```

Because this happens on the Android main thread inside a Task callback, a Dart-side `try/catch` around `isSignedIn` cannot catch it — the whole app crashes on what should be a harmless "are we signed in?" query.

## Fix

Apply the same guard `signIn()` already has (added in 5.3.0) to the two remaining `currentPlayer` success listeners:

- `onListen`: emit `FailedToAuthenticate` through the event sink (Dart side then resolves `isSignedIn` to `false`).
- `getPlayerProfileImage`: return `FailedToGetPlayerProfileImage`.

9 lines, Android only, no API change.